### PR TITLE
feat(ci): AI upstream release analyzer with draft PR batching

### DIFF
--- a/.github/prompts/commit-classify.md
+++ b/.github/prompts/commit-classify.md
@@ -1,0 +1,59 @@
+You are reviewing a single commit from an upstream open-source project that
+this fork has diverged from. The upstream repository has a known quality
+problem: the maintainers regularly merge AI-generated slop — verbose
+commented-out code, unnecessary abstractions with zero callers, boilerplate
+features behind flags nobody requested, "enhancements" that are actually
+pure churn with no behavior delta, docs that triple word count without
+adding information, and tests that assert tautologies.
+
+Your job: protect this fork from absorbing slop. Classify each commit.
+
+## Classification
+
+Return exactly one of:
+
+- **GOOD** — Real bug fix, real feature with real callers, real test that
+  covers a real case, meaningful doc addition. Clear, defensible value.
+  The fork wants this.
+
+- **NEEDS_REVIEW** — Ambiguous. Might be a legitimate refactor, might be
+  pointless churn. Might be a doc rewrite that adds clarity, might be a
+  word-count inflation. Could reasonably go either way. A human should
+  look before merging.
+
+- **SLOP** — Obvious AI-generated fluff. High confidence it adds no value.
+  Symptoms (any one is sufficient):
+  - New abstraction with exactly one caller (and no clear reason to grow)
+  - Comments that restate what the code already says
+  - Commit message uses "enhanced", "improved", "comprehensive", "robust"
+    without a measurable metric or concrete behavior delta
+  - Docs that expand existing content without adding new facts
+  - Tests that assert `expect(x).toBe(x)`-shape tautologies
+  - Features gated behind flags with no consumer requesting them
+  - Renamed symbols with no call-site benefit (churn)
+  - "Defensive" try/catch around code that cannot throw
+  - Introduces a new dependency for trivial functionality
+
+## Bias
+
+**Default to NEEDS_REVIEW when unsure.** False positives (good commits
+flagged as NEEDS_REVIEW) cost a human 60 seconds of review. False negatives
+(slop classified as GOOD) merge garbage into the fork permanently.
+
+**Do not be charitable.** The upstream has burned this trust.
+
+## Output format
+
+Return VALID JSON ONLY — no markdown fences, no prose before or after:
+
+```
+{
+  "verdict": "GOOD" | "NEEDS_REVIEW" | "SLOP",
+  "confidence": "high" | "medium" | "low",
+  "reason": "one sentence, concrete, references the actual change",
+  "slop_signals": ["signal 1", "signal 2", ...]
+}
+```
+
+`slop_signals` is a (possibly empty) array of matched symptoms from the list
+above. `reason` must reference the specific change, not generic language.

--- a/.github/prompts/release-synthesis.md
+++ b/.github/prompts/release-synthesis.md
@@ -1,0 +1,61 @@
+You are producing a cost-benefit analysis for a maintainer deciding whether
+to merge an upstream release into their fork.
+
+You will receive:
+- The from-tag and to-tag of the release window
+- The full classification results for every commit in that window
+- Aggregate stats (total commits, file-level diff stat, slop ratio)
+
+## Your job
+
+Produce a single recommendation:
+
+- **MERGE_CLEAN** — Release is mostly GOOD. Worth pulling with minor
+  review of NEEDS_REVIEW commits. Slop ratio < 15%.
+
+- **CHERRY_PICK** — Release has value but mixed with slop. Recommend
+  pulling only the GOOD batch; leave SLOP commits for human decision.
+  Slop ratio 15-40%.
+
+- **SKIP** — Release is majority slop or the GOOD commits are dependent
+  on the SLOP commits (can't cleanly extract). Slop ratio > 40% OR any
+  critical slop commit blocks the good ones.
+
+- **HOLD_FOR_HUMAN** — Too ambiguous for automation. Too many
+  NEEDS_REVIEW commits to confidently recommend. Let a human decide.
+
+## Fork-sync impact assessment
+
+Beyond GOOD/SLOP ratios, explicitly assess:
+
+1. **Breaking changes** — API removals, signature changes, config format
+   changes, behavior reversals. Does the release break anything the fork
+   depends on?
+
+2. **Dependency churn** — Did upstream add/remove/upgrade dependencies?
+   Does that conflict with the fork's dependency choices?
+
+3. **Architecture drift** — Did upstream introduce a pattern that the
+   fork explicitly rejects (e.g., the things the fork was forked over)?
+
+4. **Hidden slop in GOOD batch** — Even GOOD-classified commits may have
+   subtle issues when combined. Flag patterns like "20 tiny GOOD refactors
+   that together constitute pointless churn."
+
+## Output format
+
+Return VALID JSON ONLY:
+
+```
+{
+  "recommendation": "MERGE_CLEAN" | "CHERRY_PICK" | "SKIP" | "HOLD_FOR_HUMAN",
+  "confidence": "high" | "medium" | "low",
+  "summary": "3-5 sentence plain-English verdict",
+  "slop_ratio_percent": <number 0-100>,
+  "breaking_changes": [{"description": "...", "severity": "high|medium|low"}],
+  "dependency_changes": ["..."],
+  "architecture_drift": ["..."],
+  "hidden_concerns": ["..."],
+  "action_items": ["specific thing a human should verify before merging"]
+}
+```

--- a/.github/prompts/slop-verify.md
+++ b/.github/prompts/slop-verify.md
@@ -1,0 +1,59 @@
+You are a second-pass reviewer. A cheaper, faster model has already
+classified this commit as SLOP. Your job is to verify that verdict with
+deeper reasoning.
+
+You have stronger reasoning capability than the first-pass model. Use it.
+
+## What to decide
+
+Choose one:
+
+- **CONFIRMED_SLOP** — The first-pass was right. This commit adds no real
+  value, matches documented slop patterns, and should NOT be merged into
+  the fork as-is. A human might salvage the commit's intent by writing a
+  proper implementation from scratch.
+
+- **DEMOTE_TO_REVIEW** — The first-pass was too harsh. On deeper
+  inspection, this commit is ambiguous but not obvious slop. A human
+  should review before deciding. (Prefer this over DEMOTE_TO_GOOD when in
+  doubt.)
+
+- **DEMOTE_TO_GOOD** — The first-pass was wrong. This commit is legitimate
+  and should merge. Only choose this when the commit has clear, defensible
+  value that the first-pass model missed (e.g., a subtle correctness fix,
+  a valid refactor preparing for a follow-up, a test covering a real bug).
+
+## Reasoning requirements
+
+Before producing the verdict, reason through:
+
+1. **Is there a concrete behavior delta?** Does any runtime code path
+   change? Does any user-visible output change? Does any invariant get
+   strengthened or weakened? If no to all three, default CONFIRMED_SLOP.
+
+2. **Do the added abstractions have multiple callers or a clear growth
+   path?** One-caller abstractions without explicit plans for more are
+   slop.
+
+3. **Is the commit message accurate?** Words like "enhanced", "improved",
+   "comprehensive" without measurable metrics are tells. Check if the
+   diff matches the claim.
+
+4. **Could a senior engineer defend this commit in a code review?** If the
+   only defense is "it's not wrong", that's CONFIRMED_SLOP.
+
+5. **Is this churn?** Rename-only commits, reformatting-only commits,
+   reshuffling imports without reason — all CONFIRMED_SLOP.
+
+## Output format
+
+Return VALID JSON ONLY — no markdown fences, no prose:
+
+```
+{
+  "verdict": "CONFIRMED_SLOP" | "DEMOTE_TO_REVIEW" | "DEMOTE_TO_GOOD",
+  "reasoning": "2-4 sentences walking through your thinking",
+  "behavior_delta": "none" | "minor" | "significant",
+  "first_pass_was_correct": true | false
+}
+```

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,9 +1,18 @@
-name: Sync Upstream
+name: Sync Upstream (DISABLED)
+
+# Superseded by upstream-tag-watcher.yml + upstream-analyzer.yml.
+# The analyzer opens draft PRs per batch (good / review / slop) instead of
+# force-pushing rebased dev. This file is kept (gated off) for reference
+# and to preserve git history; delete once the analyzer pipeline is proven.
 
 on:
-  schedule:
-    - cron: "0 */6 * * *"
   workflow_dispatch:
+    inputs:
+      i_understand_this_is_legacy:
+        description: "Type EXACTLY 'yes-legacy-force-sync' to run this legacy workflow (superseded by upstream-analyzer)"
+        required: true
+        type: string
+        default: ""
 
 concurrency:
   group: sync-upstream
@@ -16,6 +25,7 @@ permissions:
 
 jobs:
   sync:
+    if: ${{ inputs.i_understand_this_is_legacy == 'yes-legacy-force-sync' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -81,31 +91,33 @@ jobs:
 
           if ! git rebase "$TARGET"; then
             git rebase --abort
-            printf 'success=false\n' >> "$GITHUB_OUTPUT"
-            printf 'head_moved=false\n' >> "$GITHUB_OUTPUT"
-            printf 'tracker_updated=false\n' >> "$GITHUB_OUTPUT"
+            {
+              echo "success=false"
+              echo "head_moved=false"
+              echo "tracker_updated=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           HEAD_AFTER_REBASE=$(git rev-parse HEAD)
           if [ "$HEAD_BEFORE" = "$HEAD_AFTER_REBASE" ]; then
-            printf 'head_moved=false\n' >> "$GITHUB_OUTPUT"
+            echo "head_moved=false" >> "$GITHUB_OUTPUT"
             echo "Rebase was a no-op (upstream tag already ancestor of dev)"
           else
-            printf 'head_moved=true\n' >> "$GITHUB_OUTPUT"
+            echo "head_moved=true" >> "$GITHUB_OUTPUT"
           fi
 
           printf '%s\n' "$TAG" > upstream-version.txt
           git add upstream-version.txt
           if git diff --cached --quiet; then
-            printf 'tracker_updated=false\n' >> "$GITHUB_OUTPUT"
+            echo "tracker_updated=false" >> "$GITHUB_OUTPUT"
             echo "Tracker already at $TAG"
           else
             git commit -m "chore(sync): track upstream ${TAG}"
-            printf 'tracker_updated=true\n' >> "$GITHUB_OUTPUT"
+            echo "tracker_updated=true" >> "$GITHUB_OUTPUT"
           fi
 
-          printf 'success=true\n' >> "$GITHUB_OUTPUT"
+          echo "success=true" >> "$GITHUB_OUTPUT"
 
       - name: Open issue on rebase failure
         if: steps.check.outputs.skip == 'false' && steps.rebase.outputs.success == 'false'

--- a/.github/workflows/upstream-analyzer.yml
+++ b/.github/workflows/upstream-analyzer.yml
@@ -1,0 +1,225 @@
+name: Upstream Analyzer
+
+# AI-powered cost-benefit review of an upstream release window.
+# Pipeline (3 passes):
+#   1. Per-commit classification (GOOD / NEEDS_REVIEW / SLOP) via gpt-4.1-mini
+#   2. Slop verification of SLOP candidates via gpt-5-mini (stronger reasoning)
+#   3. Release synthesis via gpt-4.1 (final recommendation)
+#
+# Output:
+#   - One issue with the full cost-benefit report
+#   - Up to 3 draft PRs (good / review / slop batches) with cherry-picked commits
+#
+# Phase 1 posture: ADVISORY ONLY. No auto-merge. No auto-publish.
+# Merges and release publishes remain manual decisions by the maintainer.
+
+run-name: "Upstream: ${{ github.event.inputs.from_tag || github.event.client_payload.from_tag }} → ${{ github.event.inputs.to_tag || github.event.client_payload.to_tag }}"
+
+on:
+  repository_dispatch:
+    types: [upstream-tag-detected]
+  workflow_dispatch:
+    inputs:
+      from_tag:
+        description: "Starting upstream tag (exclusive, e.g. v3.17.0)"
+        required: true
+        type: string
+      to_tag:
+        description: "Ending upstream tag (inclusive, e.g. v3.17.4)"
+        required: true
+        type: string
+      upstream_repo:
+        description: "Upstream repo slug (owner/name)"
+        required: false
+        default: "code-yeongyu/oh-my-openagent"
+        type: string
+      push_branches:
+        description: "Push batch branches to origin (needed for draft PRs)"
+        required: false
+        default: true
+        type: boolean
+      model_classify:
+        description: "Model for per-commit classification"
+        required: false
+        default: "openai/gpt-4.1-mini"
+        type: string
+      model_slop_verify:
+        description: "Primary model for slop verification second-pass"
+        required: false
+        default: "openai/gpt-5-mini"
+        type: string
+      model_slop_verify_fallbacks:
+        description: "Comma-separated fallback chain when primary verifier quota/context is exhausted"
+        required: false
+        default: "openai/gpt-4.1,openai/gpt-4.1-mini"
+        type: string
+      model_synthesis:
+        description: "Model for release synthesis"
+        required: false
+        default: "openai/gpt-4.1"
+        type: string
+
+concurrency:
+  group: upstream-analyzer-${{ github.event.inputs.to_tag || github.event.client_payload.to_tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  models: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Resolve inputs
+        id: inputs
+        env:
+          DISPATCH_FROM: ${{ github.event.client_payload.from_tag }}
+          DISPATCH_TO: ${{ github.event.client_payload.to_tag }}
+          DISPATCH_REPO: ${{ github.event.client_payload.upstream_repo }}
+          INPUT_FROM: ${{ github.event.inputs.from_tag }}
+          INPUT_TO: ${{ github.event.inputs.to_tag }}
+          INPUT_REPO: ${{ github.event.inputs.upstream_repo }}
+          INPUT_PUSH: ${{ github.event.inputs.push_branches }}
+          INPUT_CLASSIFY: ${{ github.event.inputs.model_classify }}
+          INPUT_VERIFY: ${{ github.event.inputs.model_slop_verify }}
+          INPUT_VERIFY_FALLBACKS: ${{ github.event.inputs.model_slop_verify_fallbacks }}
+          INPUT_SYNTH: ${{ github.event.inputs.model_synthesis }}
+        run: |
+          set -euo pipefail
+          FROM_TAG="${INPUT_FROM:-$DISPATCH_FROM}"
+          TO_TAG="${INPUT_TO:-$DISPATCH_TO}"
+          UPSTREAM_REPO="${INPUT_REPO:-${DISPATCH_REPO:-code-yeongyu/oh-my-openagent}}"
+          PUSH_BRANCHES="${INPUT_PUSH:-true}"
+          MODEL_CLASSIFY="${INPUT_CLASSIFY:-openai/gpt-4.1-mini}"
+          MODEL_SLOP_VERIFY="${INPUT_VERIFY:-openai/gpt-5-mini}"
+          MODEL_SLOP_VERIFY_FALLBACKS="${INPUT_VERIFY_FALLBACKS:-openai/gpt-4.1,openai/gpt-4.1-mini}"
+          MODEL_SYNTHESIS="${INPUT_SYNTH:-openai/gpt-4.1}"
+
+          if [ -z "$FROM_TAG" ] || [ -z "$TO_TAG" ]; then
+            echo "::error::from_tag and to_tag are required"
+            exit 1
+          fi
+
+          {
+            echo "from_tag=$FROM_TAG"
+            echo "to_tag=$TO_TAG"
+            echo "upstream_repo=$UPSTREAM_REPO"
+            echo "push_branches=$PUSH_BRANCHES"
+            echo "model_classify=$MODEL_CLASSIFY"
+            echo "model_slop_verify=$MODEL_SLOP_VERIFY"
+            echo "model_slop_verify_fallbacks=$MODEL_SLOP_VERIFY_FALLBACKS"
+            echo "model_synthesis=$MODEL_SYNTHESIS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          BUN_INSTALL_ALLOW_SCRIPTS: "@ast-grep/napi"
+
+      - name: Run analyzer pipeline
+        id: analyze
+        env:
+          UPSTREAM_REPO: ${{ steps.inputs.outputs.upstream_repo }}
+          FROM_TAG: ${{ steps.inputs.outputs.from_tag }}
+          TO_TAG: ${{ steps.inputs.outputs.to_tag }}
+          MODEL_CLASSIFY: ${{ steps.inputs.outputs.model_classify }}
+          MODEL_SLOP_VERIFY: ${{ steps.inputs.outputs.model_slop_verify }}
+          MODEL_SLOP_VERIFY_FALLBACKS: ${{ steps.inputs.outputs.model_slop_verify_fallbacks }}
+          MODEL_SYNTHESIS: ${{ steps.inputs.outputs.model_synthesis }}
+          PUSH_BRANCHES: ${{ steps.inputs.outputs.push_branches }}
+          OUTPUT_DIR: .analyzer-output
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run script/upstream-analyzer/run.ts
+
+      - name: Upload analyzer artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: analyzer-output-${{ steps.inputs.outputs.to_tag }}
+          path: .analyzer-output/
+          retention-days: 30
+
+      - name: Create analysis issue
+        id: issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs/promises');
+            const title = (await fs.readFile('.analyzer-output/issue-title.txt', 'utf8')).trim();
+            const body = await fs.readFile('.analyzer-output/issue-body.md', 'utf8');
+            const labels = JSON.parse(await fs.readFile('.analyzer-output/issue-labels.json', 'utf8'));
+
+            const response = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels,
+            });
+            core.setOutput('issue_number', response.data.number);
+            core.setOutput('issue_url', response.data.html_url);
+            core.notice(`Created analysis issue #${response.data.number}`);
+
+      - name: Open draft PRs for batches
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
+          TO_TAG: ${{ steps.inputs.outputs.to_tag }}
+        with:
+          script: |
+            const fs = require('node:fs/promises');
+            const specs = JSON.parse(await fs.readFile('.analyzer-output/batch-pr-specs.json', 'utf8'));
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+
+            for (const spec of specs) {
+              if (spec.skipped) {
+                core.info(`Skipping ${spec.batch} batch: no commits applied`);
+                continue;
+              }
+
+              try {
+                const prBody = spec.body + `\n\nAnalysis: #${issueNumber}`;
+                const pr = await github.rest.pulls.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: spec.title,
+                  head: spec.branchName,
+                  base: 'dev',
+                  body: prBody,
+                  draft: true,
+                });
+
+                const labels = [
+                  'upstream-sync',
+                  `batch:${spec.batch.toLowerCase().replace('_', '-')}`,
+                  `upstream-tag:${process.env.TO_TAG}`,
+                ];
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.data.number,
+                  labels,
+                });
+                core.notice(`Opened draft PR #${pr.data.number} for ${spec.batch} batch`);
+              } catch (err) {
+                core.warning(`Failed to open PR for ${spec.batch} batch: ${err.message}`);
+              }
+            }

--- a/.github/workflows/upstream-tag-watcher.yml
+++ b/.github/workflows/upstream-tag-watcher.yml
@@ -1,0 +1,121 @@
+name: Upstream Tag Watcher
+
+# Polls the upstream repo for new stable tags every 15 minutes.
+# When a new tag appears, fires repository_dispatch("upstream-tag-detected")
+# which triggers upstream-analyzer.yml. Acts as a pseudo-webhook since we
+# cannot subscribe to events on a repo we do not own.
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: upstream-tag-watcher
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+
+env:
+  UPSTREAM_REPO: code-yeongyu/oh-my-openagent
+  WATCHER_STATE_FILE: .upstream-watcher-seen-tag
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Resolve latest upstream stable tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          LATEST=$(git ls-remote --tags --refs "https://github.com/${UPSTREAM_REPO}.git" 'v*' \
+            | awk '{print $2}' \
+            | sed 's|refs/tags/||' \
+            | grep -v -- '-' \
+            | sort -V \
+            | tail -1)
+
+          if [ -z "$LATEST" ]; then
+            echo "::warning::No stable v* tags found upstream"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "latest=$LATEST"
+            echo "skip=false"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Read previously analyzed tag
+        id: read_state
+        if: steps.resolve.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          STORED=""
+          if [ -f "upstream-version.txt" ]; then
+            STORED=$(tr -d '[:space:]' < upstream-version.txt)
+          fi
+          # Optional watcher-specific state (survives even if upstream-version.txt is ahead)
+          if [ -f "${WATCHER_STATE_FILE}" ]; then
+            LAST_SEEN=$(tr -d '[:space:]' < "${WATCHER_STATE_FILE}")
+          else
+            LAST_SEEN="$STORED"
+          fi
+
+          echo "stored=$STORED" >> "$GITHUB_OUTPUT"
+          echo "last_seen=$LAST_SEEN" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to dispatch analyzer
+        id: decide
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          LATEST: ${{ steps.resolve.outputs.latest }}
+          LAST_SEEN: ${{ steps.read_state.outputs.last_seen }}
+          STORED: ${{ steps.read_state.outputs.stored }}
+        run: |
+          set -euo pipefail
+          if [ "$LATEST" = "$LAST_SEEN" ]; then
+            echo "Upstream unchanged at $LATEST"
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FROM_TAG="${STORED:-$LAST_SEEN}"
+          if [ -z "$FROM_TAG" ]; then
+            echo "::warning::No baseline tag recorded; cannot compute range. Set upstream-version.txt first."
+            echo "dispatch=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Upstream moved: $FROM_TAG -> $LATEST"
+          {
+            echo "from_tag=$FROM_TAG"
+            echo "to_tag=$LATEST"
+            echo "dispatch=true"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fire repository_dispatch to analyzer
+        if: steps.decide.outputs.dispatch == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const payload = {
+              from_tag: '${{ steps.decide.outputs.from_tag }}',
+              to_tag: '${{ steps.decide.outputs.to_tag }}',
+              upstream_repo: process.env.UPSTREAM_REPO,
+              detected_at: new Date().toISOString(),
+            };
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'upstream-tag-detected',
+              client_payload: payload,
+            });
+            core.notice(`Dispatched analyzer for ${payload.from_tag} -> ${payload.to_tag}`);

--- a/script/upstream-analyzer/batch-builder.ts
+++ b/script/upstream-analyzer/batch-builder.ts
@@ -1,0 +1,100 @@
+import {
+  createBranchFromTag,
+  cherryPickCommit,
+  pushBranch,
+  tagExists,
+} from "./git-inspector"
+import type { CommitClassification, CommitVerdict } from "./types"
+
+export interface BatchResult {
+  batch: CommitVerdict
+  branchName: string
+  baseTag: string
+  appliedCommits: string[]
+  conflictCommits: string[]
+  skipped: boolean
+}
+
+interface BatchBuilderInput {
+  fromTag: string
+  toTag: string
+  classifications: CommitClassification[]
+  branchPrefix: string
+}
+
+const BATCH_ORDER: CommitVerdict[] = ["GOOD", "NEEDS_REVIEW", "SLOP"]
+
+function slugifyTag(tag: string): string {
+  return tag.replace(/[^a-zA-Z0-9._-]/g, "-")
+}
+
+function batchBranchName(prefix: string, tag: string, batch: CommitVerdict): string {
+  const verdictSlug = batch.toLowerCase().replace("_", "-")
+  return `${prefix}/${slugifyTag(tag)}-${verdictSlug}`
+}
+
+function commitsForBatch(
+  classifications: CommitClassification[],
+  batch: CommitVerdict,
+): CommitClassification[] {
+  return classifications.filter((c) => c.verdict === batch)
+}
+
+async function buildSingleBatch(
+  input: BatchBuilderInput,
+  batch: CommitVerdict,
+): Promise<BatchResult> {
+  const branchName = batchBranchName(input.branchPrefix, input.toTag, batch)
+  const commits = commitsForBatch(input.classifications, batch)
+
+  if (commits.length === 0) {
+    return {
+      batch,
+      branchName,
+      baseTag: input.fromTag,
+      appliedCommits: [],
+      conflictCommits: [],
+      skipped: true,
+    }
+  }
+
+  if (!(await tagExists(input.fromTag))) {
+    throw new Error(`Base tag ${input.fromTag} not found locally`)
+  }
+
+  await createBranchFromTag(branchName, input.fromTag)
+
+  const applied: string[] = []
+  const conflicts: string[] = []
+
+  for (const commit of commits) {
+    const status = await cherryPickCommit(commit.sha)
+    if (status === "ok") applied.push(commit.sha)
+    else conflicts.push(commit.sha)
+  }
+
+  return {
+    batch,
+    branchName,
+    baseTag: input.fromTag,
+    appliedCommits: applied,
+    conflictCommits: conflicts,
+    skipped: false,
+  }
+}
+
+export async function buildAllBatches(input: BatchBuilderInput): Promise<BatchResult[]> {
+  const results: BatchResult[] = []
+  for (const batch of BATCH_ORDER) {
+    results.push(await buildSingleBatch(input, batch))
+  }
+  return results
+}
+
+export async function pushBatches(results: BatchResult[]): Promise<void> {
+  for (const result of results) {
+    if (result.skipped) continue
+    if (result.appliedCommits.length === 0) continue
+    await pushBranch(result.branchName)
+  }
+}

--- a/script/upstream-analyzer/cli-config.ts
+++ b/script/upstream-analyzer/cli-config.ts
@@ -1,0 +1,57 @@
+import type { AnalyzerConfig } from "./types"
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Required env var ${name} is not set`)
+  }
+  return value
+}
+
+function optionalEnv(name: string, fallback: string): string {
+  const value = process.env[name]
+  return value && value.length > 0 ? value : fallback
+}
+
+function parseModelList(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+function parseRepoSlug(slug: string): { owner: string; name: string } {
+  const [owner, name] = slug.split("/")
+  if (!owner || !name) {
+    throw new Error(`Invalid repo slug: ${slug} (expected owner/name)`)
+  }
+  return { owner, name }
+}
+
+export function loadConfigFromEnv(): AnalyzerConfig {
+  const upstreamRepo = requireEnv("UPSTREAM_REPO")
+  const fromTag = requireEnv("FROM_TAG")
+  const toTag = requireEnv("TO_TAG")
+  const githubRepository = requireEnv("GITHUB_REPOSITORY")
+  const { owner, name } = parseRepoSlug(githubRepository)
+
+  return {
+    upstreamRepo,
+    fromTag,
+    toTag,
+    modelClassify: optionalEnv("MODEL_CLASSIFY", "openai/gpt-4.1-mini"),
+    modelSlopVerify: optionalEnv("MODEL_SLOP_VERIFY", "openai/gpt-5-mini"),
+    modelSlopVerifyFallbacks: parseModelList(
+      optionalEnv("MODEL_SLOP_VERIFY_FALLBACKS", "openai/gpt-4.1,openai/gpt-4.1-mini"),
+    ),
+    modelSynthesis: optionalEnv("MODEL_SYNTHESIS", "openai/gpt-4.1"),
+    repoOwner: owner,
+    repoName: name,
+    outputDir: optionalEnv("OUTPUT_DIR", ".analyzer-output"),
+  }
+}
+
+export function shouldPushBranches(): boolean {
+  const value = (process.env.PUSH_BRANCHES ?? "false").toLowerCase()
+  return value === "true" || value === "1" || value === "yes"
+}

--- a/script/upstream-analyzer/commit-classifier.ts
+++ b/script/upstream-analyzer/commit-classifier.ts
@@ -1,0 +1,101 @@
+import { getCommitDiff } from "./git-inspector"
+import { inferJson } from "./github-models-client"
+import type { CommitClassification, CommitMeta, CommitVerdict } from "./types"
+
+const MAX_TOKENS_OUT = 512
+
+function buildUserPrompt(commit: CommitMeta, diff: string): string {
+  return [
+    `Commit: ${commit.shortSha}`,
+    `Author: ${commit.author}`,
+    `Date: ${commit.date}`,
+    `Subject: ${commit.subject}`,
+    "",
+    "Full diff:",
+    diff,
+  ].join("\n")
+}
+
+function normalizeVerdict(raw: unknown): CommitVerdict {
+  if (raw === "GOOD" || raw === "NEEDS_REVIEW" || raw === "SLOP") return raw
+  return "NEEDS_REVIEW"
+}
+
+function normalizeConfidence(raw: unknown): "high" | "medium" | "low" {
+  if (raw === "high" || raw === "medium" || raw === "low") return raw
+  return "medium"
+}
+
+function normalizeReason(raw: unknown): string {
+  if (typeof raw !== "string" || !raw.trim()) return "Model did not return a reason"
+  return raw.trim()
+}
+
+function normalizeSlopSignals(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter((x): x is string => typeof x === "string")
+}
+
+function fallbackClassification(commit: CommitMeta, reason: string): CommitClassification {
+  return {
+    sha: commit.sha,
+    shortSha: commit.shortSha,
+    subject: commit.subject,
+    verdict: "NEEDS_REVIEW",
+    confidence: "low",
+    reason: `Classification failed: ${reason}`,
+    slopSignals: [],
+  }
+}
+
+export async function classifyCommit(
+  commit: CommitMeta,
+  systemPrompt: string,
+  model: string,
+): Promise<CommitClassification> {
+  const diff = await getCommitDiff(commit.sha)
+
+  let parsed: unknown
+  try {
+    const result = await inferJson({
+      model,
+      systemPrompt,
+      userPrompt: buildUserPrompt(commit, diff),
+      maxTokens: MAX_TOKENS_OUT,
+      temperature: 0.1,
+    })
+    parsed = result.parsed
+  } catch (cause) {
+    return fallbackClassification(commit, (cause as Error).message)
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return fallbackClassification(commit, "Model returned non-JSON output")
+  }
+
+  const record = parsed as Record<string, unknown>
+  return {
+    sha: commit.sha,
+    shortSha: commit.shortSha,
+    subject: commit.subject,
+    verdict: normalizeVerdict(record.verdict),
+    confidence: normalizeConfidence(record.confidence),
+    reason: normalizeReason(record.reason),
+    slopSignals: normalizeSlopSignals(record.slop_signals),
+  }
+}
+
+export async function classifyCommitsSequentially(
+  commits: CommitMeta[],
+  systemPrompt: string,
+  model: string,
+  onProgress?: (index: number, total: number, classification: CommitClassification) => void,
+): Promise<CommitClassification[]> {
+  const results: CommitClassification[] = []
+  for (let i = 0; i < commits.length; i++) {
+    const classification = await classifyCommit(commits[i], systemPrompt, model)
+    results.push(classification)
+    onProgress?.(i + 1, commits.length, classification)
+  }
+  return results
+}

--- a/script/upstream-analyzer/git-inspector.ts
+++ b/script/upstream-analyzer/git-inspector.ts
@@ -1,0 +1,65 @@
+import { $ } from "bun"
+import type { CommitMeta } from "./types"
+
+const DEFAULT_DIFF_CHARS = 24000
+
+export async function ensureUpstreamRemote(upstreamRepo: string): Promise<void> {
+  await $`git remote remove upstream`.quiet().nothrow()
+  await $`git remote add upstream https://github.com/${upstreamRepo}.git`.quiet()
+  await $`git fetch --tags upstream`.quiet()
+}
+
+export async function tagExists(tag: string): Promise<boolean> {
+  const result = await $`git rev-parse --verify ${tag}`.quiet().nothrow()
+  return result.exitCode === 0
+}
+
+export async function listCommitsInRange(fromTag: string, toTag: string): Promise<CommitMeta[]> {
+  const format = "%H%x09%h%x09%s%x09%an%x09%aI"
+  const output = await $`git log --reverse --no-merges --format=${format} ${fromTag}..${toTag}`.text()
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, shortSha, subject, author, date] = line.split("\t")
+      return { sha, shortSha, subject, author, date }
+    })
+}
+
+export async function getCommitDiff(sha: string, maxChars: number = DEFAULT_DIFF_CHARS): Promise<string> {
+  const diff = await $`git show --no-color --format=fuller ${sha}`.text()
+  if (diff.length <= maxChars) return diff
+  return `${diff.slice(0, maxChars)}\n\n...[diff truncated at ${maxChars} chars]`
+}
+
+export async function getReleaseDiffStat(fromTag: string, toTag: string): Promise<string> {
+  return (await $`git diff --stat ${fromTag}..${toTag}`.text()).trim()
+}
+
+export async function getDependencyChanges(fromTag: string, toTag: string): Promise<string> {
+  const result = await $`git diff ${fromTag}..${toTag} -- package.json`.quiet().nothrow()
+  if (result.exitCode !== 0) return ""
+  return result.text()
+}
+
+export async function createBranchFromTag(branchName: string, baseTag: string): Promise<void> {
+  await $`git branch -D ${branchName}`.quiet().nothrow()
+  await $`git checkout -b ${branchName} ${baseTag}`.quiet()
+}
+
+export async function cherryPickCommit(sha: string): Promise<"ok" | "conflict"> {
+  const result = await $`git cherry-pick --allow-empty --keep-redundant-commits ${sha}`.quiet().nothrow()
+  if (result.exitCode === 0) return "ok"
+  await $`git cherry-pick --abort`.quiet().nothrow()
+  return "conflict"
+}
+
+export async function getCurrentBranch(): Promise<string> {
+  return (await $`git rev-parse --abbrev-ref HEAD`.text()).trim()
+}
+
+export async function pushBranch(branch: string): Promise<void> {
+  await $`git push origin ${branch} --force-with-lease`.quiet()
+}

--- a/script/upstream-analyzer/github-models-client.ts
+++ b/script/upstream-analyzer/github-models-client.ts
@@ -1,0 +1,157 @@
+const ENDPOINT = "https://models.github.ai/inference/chat/completions"
+
+interface ChatMessage {
+  role: "system" | "user" | "assistant"
+  content: string
+}
+
+interface InferenceRequest {
+  model: string
+  systemPrompt: string
+  userPrompt: string
+  maxTokens: number
+  temperature?: number
+}
+
+interface InferenceResult {
+  raw: string
+  parsed: unknown
+  modelUsed: string
+}
+
+class GithubModelsError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: string,
+  ) {
+    super(message)
+    this.name = "GithubModelsError"
+  }
+}
+
+function requireToken(): string {
+  const token = process.env.GITHUB_TOKEN
+  if (!token) {
+    throw new Error("GITHUB_TOKEN not set. Workflow needs permissions.models: read.")
+  }
+  return token
+}
+
+function stripMarkdownFences(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .trim()
+}
+
+function parseJsonResponse(raw: string): unknown {
+  const stripped = stripMarkdownFences(raw)
+  try {
+    return JSON.parse(stripped)
+  } catch {
+    return null
+  }
+}
+
+async function postChatCompletion(
+  token: string,
+  model: string,
+  messages: ChatMessage[],
+  maxTokens: number,
+  temperature: number,
+): Promise<string> {
+  const response = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: maxTokens,
+      temperature,
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new GithubModelsError(`GitHub Models returned ${response.status}`, response.status, body)
+  }
+
+  const data = (await response.json()) as { choices?: Array<{ message?: { content?: string } }> }
+  const content = data.choices?.[0]?.message?.content
+  if (!content) {
+    throw new Error("GitHub Models returned empty completion")
+  }
+  return content
+}
+
+export async function inferJson(req: InferenceRequest): Promise<InferenceResult> {
+  const token = requireToken()
+  const raw = await postChatCompletion(
+    token,
+    req.model,
+    [
+      { role: "system", content: req.systemPrompt },
+      { role: "user", content: req.userPrompt },
+    ],
+    req.maxTokens,
+    req.temperature ?? 0.1,
+  )
+  return { raw, parsed: parseJsonResponse(raw), modelUsed: req.model }
+}
+
+function isQuotaError(err: unknown): boolean {
+  if (!(err instanceof GithubModelsError)) return false
+  if (err.status === 429) return true
+  if (err.status === 403) return /rate[_-]?limit|quota|exceed/i.test(err.body)
+  return false
+}
+
+function isContextLengthError(err: unknown): boolean {
+  if (!(err instanceof GithubModelsError)) return false
+  if (err.status !== 400) return false
+  return /context[_ -]?length|token|too[_ -]?long|maximum/i.test(err.body)
+}
+
+export function shouldFallback(err: unknown): boolean {
+  return isQuotaError(err) || isContextLengthError(err)
+}
+
+export interface FallbackInferenceRequest extends Omit<InferenceRequest, "model"> {
+  primaryModel: string
+  fallbackModels: string[]
+  onFallback?: (failedModel: string, nextModel: string, reason: string) => void
+}
+
+export async function inferJsonWithFallback(
+  req: FallbackInferenceRequest,
+): Promise<InferenceResult> {
+  const chain = [req.primaryModel, ...req.fallbackModels]
+  let lastError: unknown
+  for (let i = 0; i < chain.length; i++) {
+    const model = chain[i]
+    try {
+      return await inferJson({
+        model,
+        systemPrompt: req.systemPrompt,
+        userPrompt: req.userPrompt,
+        maxTokens: req.maxTokens,
+        temperature: req.temperature,
+      })
+    } catch (err) {
+      lastError = err
+      const isLast = i === chain.length - 1
+      if (isLast || !shouldFallback(err)) throw err
+      const reason = err instanceof GithubModelsError ? `${err.status} ${err.body.slice(0, 160)}` : String(err)
+      req.onFallback?.(model, chain[i + 1], reason)
+    }
+  }
+  throw lastError ?? new Error("inferJsonWithFallback exhausted without error (unreachable)")
+}
+
+export { GithubModelsError }

--- a/script/upstream-analyzer/index.ts
+++ b/script/upstream-analyzer/index.ts
@@ -1,0 +1,15 @@
+export { runPipeline } from "./pipeline"
+export type { PipelineResult, PipelineRunOptions } from "./pipeline"
+export { loadConfigFromEnv, shouldPushBranches } from "./cli-config"
+export type {
+  AnalyzerConfig,
+  CommitClassification,
+  CommitMeta,
+  CommitVerdict,
+  PipelineOutput,
+  SlopVerification,
+  SynthesisRecommendation,
+  SynthesisResult,
+} from "./types"
+export { buildIssueBody, buildIssueTitle, buildIssueLabels, buildBatchPrBody } from "./issue-report"
+export type { BatchResult } from "./batch-builder"

--- a/script/upstream-analyzer/issue-report.ts
+++ b/script/upstream-analyzer/issue-report.ts
@@ -1,0 +1,211 @@
+import type { BatchResult } from "./batch-builder"
+import type {
+  AnalyzerConfig,
+  CommitClassification,
+  CommitVerdict,
+  SlopVerification,
+  SynthesisResult,
+} from "./types"
+
+const RECOMMENDATION_EMOJI: Record<SynthesisResult["recommendation"], string> = {
+  MERGE_CLEAN: "🟢",
+  CHERRY_PICK: "🟡",
+  SKIP: "🔴",
+  HOLD_FOR_HUMAN: "⚪",
+}
+
+function countByVerdict(classifications: CommitClassification[]): Record<CommitVerdict, number> {
+  return {
+    GOOD: classifications.filter((c) => c.verdict === "GOOD").length,
+    NEEDS_REVIEW: classifications.filter((c) => c.verdict === "NEEDS_REVIEW").length,
+    SLOP: classifications.filter((c) => c.verdict === "SLOP").length,
+  }
+}
+
+function renderCommitLines(commits: CommitClassification[]): string {
+  if (commits.length === 0) return "_(none)_"
+  return commits
+    .map((c) => `- \`${c.shortSha}\` **${c.subject}** — ${c.reason}`)
+    .join("\n")
+}
+
+function renderBatchSection(
+  heading: string,
+  description: string,
+  commits: CommitClassification[],
+  batch: BatchResult | undefined,
+): string {
+  const conflictNote =
+    batch && batch.conflictCommits.length > 0
+      ? `\n> ⚠️ ${batch.conflictCommits.length} commit(s) failed to cherry-pick and are NOT in the draft PR.`
+      : ""
+  const branchNote = batch && !batch.skipped ? `\nBranch: \`${batch.branchName}\`${conflictNote}` : ""
+  return [`### ${heading}`, `_${description}_`, "", renderCommitLines(commits), branchNote, ""].join("\n")
+}
+
+function renderVerifications(verifications: SlopVerification[]): string {
+  if (verifications.length === 0) return ""
+  const lines = verifications.map(
+    (v) =>
+      `- \`${v.sha.slice(0, 7)}\` ${v.verifyResult} (behavior delta: ${v.behaviorDelta}) — ${v.reasoning}`,
+  )
+  return ["### Slop verifier second-pass notes", "", ...lines, ""].join("\n")
+}
+
+function renderBreakingChanges(items: SynthesisResult["breakingChanges"]): string {
+  if (items.length === 0) return "_(none detected)_"
+  return items.map((bc) => `- **[${bc.severity}]** ${bc.description}`).join("\n")
+}
+
+function renderStringList(items: string[]): string {
+  if (items.length === 0) return "_(none)_"
+  return items.map((item) => `- ${item}`).join("\n")
+}
+
+function renderActionItems(items: string[]): string {
+  if (items.length === 0) return "_(none)_"
+  return items.map((item) => `- [ ] ${item}`).join("\n")
+}
+
+interface IssueReportInput {
+  config: AnalyzerConfig
+  classifications: CommitClassification[]
+  verifications: SlopVerification[]
+  synthesis: SynthesisResult
+  batches: BatchResult[]
+}
+
+function buildHeader(input: IssueReportInput): string {
+  const { config, synthesis } = input
+  const emoji = RECOMMENDATION_EMOJI[synthesis.recommendation]
+  return [
+    `# ${emoji} Upstream cost-benefit: ${config.fromTag} → ${config.toTag}`,
+    "",
+    `**Upstream:** \`${config.upstreamRepo}\`  `,
+    `**Recommendation:** \`${synthesis.recommendation}\` (confidence: ${synthesis.confidence})  `,
+    `**Slop ratio:** ${synthesis.slopRatioPercent}%  `,
+    "",
+    synthesis.summary,
+    "",
+  ].join("\n")
+}
+
+function buildBatchSummary(input: IssueReportInput): string {
+  const counts = countByVerdict(input.classifications)
+  const findBatch = (v: CommitVerdict) => input.batches.find((b) => b.batch === v)
+  return [
+    "## Batch classification",
+    "",
+    `| Verdict | Count | Branch |`,
+    `|---|---|---|`,
+    `| 🟢 GOOD | ${counts.GOOD} | \`${findBatch("GOOD")?.branchName ?? "n/a"}\` |`,
+    `| 🟡 NEEDS_REVIEW | ${counts.NEEDS_REVIEW} | \`${findBatch("NEEDS_REVIEW")?.branchName ?? "n/a"}\` |`,
+    `| 🔴 SLOP | ${counts.SLOP} | \`${findBatch("SLOP")?.branchName ?? "n/a"}\` |`,
+    "",
+  ].join("\n")
+}
+
+function buildBatchDetails(input: IssueReportInput): string {
+  const goodBatch = input.batches.find((b) => b.batch === "GOOD")
+  const reviewBatch = input.batches.find((b) => b.batch === "NEEDS_REVIEW")
+  const slopBatch = input.batches.find((b) => b.batch === "SLOP")
+
+  const goodCommits = input.classifications.filter((c) => c.verdict === "GOOD")
+  const reviewCommits = input.classifications.filter((c) => c.verdict === "NEEDS_REVIEW")
+  const slopCommits = input.classifications.filter((c) => c.verdict === "SLOP")
+
+  return [
+    renderBatchSection("🟢 Good batch", "Classified as real value. Candidate for merge.", goodCommits, goodBatch),
+    renderBatchSection(
+      "🟡 Review batch",
+      "Ambiguous. Human should review before merging.",
+      reviewCommits,
+      reviewBatch,
+    ),
+    renderBatchSection(
+      "🔴 Slop batch",
+      "Classified as AI slop or pointless churn. Do not merge as-is; rewrite intent if salvageable.",
+      slopCommits,
+      slopBatch,
+    ),
+  ].join("\n")
+}
+
+function buildSynthesisDetails(synthesis: SynthesisResult): string {
+  return [
+    "## Fork-sync impact assessment",
+    "",
+    "### Breaking changes",
+    renderBreakingChanges(synthesis.breakingChanges),
+    "",
+    "### Dependency changes",
+    renderStringList(synthesis.dependencyChanges),
+    "",
+    "### Architecture drift",
+    renderStringList(synthesis.architectureDrift),
+    "",
+    "### Hidden concerns",
+    renderStringList(synthesis.hiddenConcerns),
+    "",
+    "### Action items before merging",
+    renderActionItems(synthesis.actionItems),
+    "",
+  ].join("\n")
+}
+
+function buildFooter(config: AnalyzerConfig): string {
+  return [
+    "---",
+    "",
+    "_Generated by `upstream-analyzer` workflow. This issue is advisory — no merges or publishes happen automatically. Phase 1: draft PRs only. The prompt lives in `.github/prompts/` and is editable without touching workflow code._",
+    "",
+    `_Models: classify=\`${config.modelClassify}\` | verify=\`${[config.modelSlopVerify, ...config.modelSlopVerifyFallbacks].join(" → ")}\` | synthesis=\`${config.modelSynthesis}\`._`,
+  ].join("\n")
+}
+
+export function buildIssueTitle(config: AnalyzerConfig, synthesis: SynthesisResult): string {
+  const emoji = RECOMMENDATION_EMOJI[synthesis.recommendation]
+  return `${emoji} Upstream ${config.fromTag} → ${config.toTag}: ${synthesis.recommendation} (slop ${synthesis.slopRatioPercent}%)`
+}
+
+export function buildIssueBody(input: IssueReportInput): string {
+  return [
+    buildHeader(input),
+    buildBatchSummary(input),
+    buildBatchDetails(input),
+    renderVerifications(input.verifications),
+    buildSynthesisDetails(input.synthesis),
+    buildFooter(input.config),
+  ]
+    .filter(Boolean)
+    .join("\n")
+}
+
+export function buildIssueLabels(synthesis: SynthesisResult, toTag: string): string[] {
+  const recommendationLabel = `upstream:${synthesis.recommendation.toLowerCase().replace("_", "-")}`
+  const tagLabel = `upstream-tag:${toTag}`
+  return ["cost-benefit", "upstream-review", recommendationLabel, tagLabel]
+}
+
+export function buildBatchPrBody(
+  batch: BatchResult,
+  classifications: CommitClassification[],
+  issueNumber: number | null,
+): string {
+  const commits = classifications.filter((c) => c.verdict === batch.batch)
+  const issueRef = issueNumber ? `Closes analysis issue: #${issueNumber}\n\n` : ""
+  const conflictWarning =
+    batch.conflictCommits.length > 0
+      ? `\n> ⚠️ ${batch.conflictCommits.length} commit(s) failed to cherry-pick and were skipped. See issue for full list.\n`
+      : ""
+  return [
+    `Draft PR for the **${batch.batch}** batch of upstream ${batch.baseTag} → \`${batch.branchName}\`.`,
+    "",
+    issueRef,
+    `This PR is **not auto-mergeable**. Phase 1 of the upstream-analyzer pipeline is advisory only.`,
+    conflictWarning,
+    "### Commits in this batch",
+    "",
+    renderCommitLines(commits),
+  ].join("\n")
+}

--- a/script/upstream-analyzer/pipeline.ts
+++ b/script/upstream-analyzer/pipeline.ts
@@ -1,0 +1,160 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { buildAllBatches, pushBatches } from "./batch-builder"
+import type { BatchResult } from "./batch-builder"
+import { applyVerificationsToClassifications, verifySlopCommits } from "./slop-verifier"
+import { classifyCommitsSequentially } from "./commit-classifier"
+import { ensureUpstreamRemote, listCommitsInRange, tagExists } from "./git-inspector"
+import { loadAllPrompts } from "./prompt-loader"
+import { synthesizeRelease } from "./release-synthesizer"
+import type {
+  AnalyzerConfig,
+  CommitClassification,
+  PipelineOutput,
+  SlopVerification,
+  SynthesisResult,
+} from "./types"
+
+async function writeArtifact(outputDir: string, name: string, data: unknown): Promise<void> {
+  await mkdir(outputDir, { recursive: true })
+  const path = join(outputDir, name)
+  await writeFile(path, JSON.stringify(data, null, 2), "utf8")
+}
+
+function logProgress(step: string, detail: string): void {
+  console.log(`[analyzer] ${step}: ${detail}`)
+}
+
+async function prepareUpstreamRange(config: AnalyzerConfig): Promise<void> {
+  logProgress("setup", `fetching ${config.upstreamRepo}`)
+  await ensureUpstreamRemote(config.upstreamRepo)
+  for (const tag of [config.fromTag, config.toTag]) {
+    if (!(await tagExists(tag))) {
+      throw new Error(`Tag ${tag} not found after fetching upstream`)
+    }
+  }
+}
+
+async function runPass1Classify(
+  config: AnalyzerConfig,
+  systemPrompt: string,
+): Promise<CommitClassification[]> {
+  const commits = await listCommitsInRange(config.fromTag, config.toTag)
+  logProgress("pass1", `classifying ${commits.length} commits with ${config.modelClassify}`)
+  if (commits.length === 0) {
+    logProgress("pass1", "no commits in range, nothing to do")
+    return []
+  }
+  return classifyCommitsSequentially(commits, systemPrompt, config.modelClassify, (i, n, c) => {
+    logProgress("pass1", `${i}/${n} ${c.shortSha} => ${c.verdict}`)
+  })
+}
+
+async function runPass2Verify(
+  config: AnalyzerConfig,
+  classifications: CommitClassification[],
+  systemPrompt: string,
+): Promise<{ verifications: SlopVerification[]; final: CommitClassification[] }> {
+  const slopCount = classifications.filter((c) => c.verdict === "SLOP").length
+  if (slopCount === 0) {
+    logProgress("pass2", "no SLOP candidates, skipping slop verifier")
+    return { verifications: [], final: classifications }
+  }
+  const chainDescription = [config.modelSlopVerify, ...config.modelSlopVerifyFallbacks].join(" -> ")
+  logProgress("pass2", `verifying ${slopCount} SLOP candidates (chain: ${chainDescription})`)
+  const verifications = await verifySlopCommits(classifications, systemPrompt, {
+    primary: config.modelSlopVerify,
+    fallbacks: config.modelSlopVerifyFallbacks,
+  })
+  const final = applyVerificationsToClassifications(classifications, verifications)
+  return { verifications, final }
+}
+
+async function runPass3Synthesize(
+  config: AnalyzerConfig,
+  classifications: CommitClassification[],
+  systemPrompt: string,
+): Promise<SynthesisResult> {
+  logProgress("pass3", `synthesizing release verdict with ${config.modelSynthesis}`)
+  return synthesizeRelease({
+    fromTag: config.fromTag,
+    toTag: config.toTag,
+    upstreamRepo: config.upstreamRepo,
+    classifications,
+    model: config.modelSynthesis,
+    systemPrompt,
+  })
+}
+
+async function runBatchBuilding(
+  config: AnalyzerConfig,
+  classifications: CommitClassification[],
+): Promise<BatchResult[]> {
+  logProgress("batches", "building good / review / slop branches")
+  const results = await buildAllBatches({
+    fromTag: config.fromTag,
+    toTag: config.toTag,
+    classifications,
+    branchPrefix: "sync/upstream",
+  })
+  for (const result of results) {
+    if (result.skipped) {
+      logProgress("batches", `${result.batch}: skipped (no commits)`)
+      continue
+    }
+    logProgress(
+      "batches",
+      `${result.batch}: ${result.appliedCommits.length} applied / ${result.conflictCommits.length} conflicts on ${result.branchName}`,
+    )
+  }
+  return results
+}
+
+async function pushIfRequested(results: BatchResult[], shouldPush: boolean): Promise<void> {
+  if (!shouldPush) {
+    logProgress("push", "skipping push (dry run or pushBranches=false)")
+    return
+  }
+  logProgress("push", "pushing batch branches")
+  await pushBatches(results)
+}
+
+export interface PipelineRunOptions {
+  config: AnalyzerConfig
+  pushBranches: boolean
+}
+
+export interface PipelineResult extends PipelineOutput {
+  batches: BatchResult[]
+}
+
+export async function runPipeline(options: PipelineRunOptions): Promise<PipelineResult> {
+  const prompts = await loadAllPrompts()
+  await prepareUpstreamRange(options.config)
+
+  const initialClassifications = await runPass1Classify(options.config, prompts.commitClassify)
+  const { verifications, final } = await runPass2Verify(
+    options.config,
+    initialClassifications,
+    prompts.slopVerify,
+  )
+  const synthesis = await runPass3Synthesize(options.config, final, prompts.releaseSynthesis)
+  const batches = await runBatchBuilding(options.config, final)
+  await pushIfRequested(batches, options.pushBranches)
+
+  const result: PipelineResult = {
+    config: options.config,
+    commits: final,
+    verifications,
+    synthesis,
+    batches,
+  }
+
+  await writeArtifact(options.config.outputDir, "classifications.json", final)
+  await writeArtifact(options.config.outputDir, "verifications.json", verifications)
+  await writeArtifact(options.config.outputDir, "synthesis.json", synthesis)
+  await writeArtifact(options.config.outputDir, "batches.json", batches)
+  await writeArtifact(options.config.outputDir, "pipeline-result.json", result)
+
+  return result
+}

--- a/script/upstream-analyzer/prompt-loader.ts
+++ b/script/upstream-analyzer/prompt-loader.ts
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+const PROMPT_DIR = ".github/prompts"
+
+const PROMPT_FILES = {
+  commitClassify: "commit-classify.md",
+  slopVerify: "slop-verify.md",
+  releaseSynthesis: "release-synthesis.md",
+} as const
+
+export type PromptName = keyof typeof PROMPT_FILES
+
+export async function loadPrompt(name: PromptName): Promise<string> {
+  const filename = PROMPT_FILES[name]
+  const path = join(PROMPT_DIR, filename)
+  try {
+    return (await readFile(path, "utf8")).trim()
+  } catch (cause) {
+    throw new Error(`Failed to load prompt ${name} from ${path}: ${(cause as Error).message}`)
+  }
+}
+
+export async function loadAllPrompts(): Promise<Record<PromptName, string>> {
+  const [commitClassify, slopVerify, releaseSynthesis] = await Promise.all([
+    loadPrompt("commitClassify"),
+    loadPrompt("slopVerify"),
+    loadPrompt("releaseSynthesis"),
+  ])
+  return { commitClassify, slopVerify, releaseSynthesis }
+}

--- a/script/upstream-analyzer/release-synthesizer.ts
+++ b/script/upstream-analyzer/release-synthesizer.ts
@@ -1,0 +1,162 @@
+import { getReleaseDiffStat, getDependencyChanges } from "./git-inspector"
+import { inferJson } from "./github-models-client"
+import type {
+  CommitClassification,
+  SynthesisRecommendation,
+  SynthesisResult,
+} from "./types"
+
+const MAX_TOKENS_OUT = 1024
+const MAX_DEP_DIFF_CHARS = 6000
+
+interface SynthesisInput {
+  fromTag: string
+  toTag: string
+  upstreamRepo: string
+  classifications: CommitClassification[]
+  model: string
+  systemPrompt: string
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}\n...[truncated]`
+}
+
+function computeSlopRatio(classifications: CommitClassification[]): number {
+  if (classifications.length === 0) return 0
+  const slopCount = classifications.filter((c) => c.verdict === "SLOP").length
+  return Math.round((slopCount / classifications.length) * 100)
+}
+
+function buildCommitSummary(classifications: CommitClassification[]): string {
+  return classifications
+    .map((c) => `- [${c.verdict}] ${c.shortSha} ${c.subject} :: ${c.reason}`)
+    .join("\n")
+}
+
+async function buildUserPrompt(input: SynthesisInput): Promise<string> {
+  const diffStat = await getReleaseDiffStat(input.fromTag, input.toTag)
+  const depDiff = truncate(
+    await getDependencyChanges(input.fromTag, input.toTag),
+    MAX_DEP_DIFF_CHARS,
+  )
+
+  const counts = {
+    good: input.classifications.filter((c) => c.verdict === "GOOD").length,
+    review: input.classifications.filter((c) => c.verdict === "NEEDS_REVIEW").length,
+    slop: input.classifications.filter((c) => c.verdict === "SLOP").length,
+  }
+
+  return [
+    `Upstream: ${input.upstreamRepo}`,
+    `Release window: ${input.fromTag} -> ${input.toTag}`,
+    `Total commits: ${input.classifications.length}`,
+    `GOOD: ${counts.good} | NEEDS_REVIEW: ${counts.review} | SLOP: ${counts.slop}`,
+    "",
+    "Diff stat:",
+    diffStat || "(empty)",
+    "",
+    "Dependency changes (package.json diff):",
+    depDiff || "(none)",
+    "",
+    "Per-commit classifications:",
+    buildCommitSummary(input.classifications),
+  ].join("\n")
+}
+
+function normalizeRecommendation(raw: unknown): SynthesisRecommendation {
+  if (
+    raw === "MERGE_CLEAN" ||
+    raw === "CHERRY_PICK" ||
+    raw === "SKIP" ||
+    raw === "HOLD_FOR_HUMAN"
+  ) {
+    return raw
+  }
+  return "HOLD_FOR_HUMAN"
+}
+
+function normalizeSeverity(raw: unknown): "high" | "medium" | "low" {
+  if (raw === "high" || raw === "medium" || raw === "low") return raw
+  return "low"
+}
+
+function normalizeBreakingChanges(raw: unknown): SynthesisResult["breakingChanges"] {
+  if (!Array.isArray(raw)) return []
+  const result: SynthesisResult["breakingChanges"] = []
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) continue
+    const record = entry as Record<string, unknown>
+    const description = typeof record.description === "string" ? record.description : ""
+    if (!description) continue
+    result.push({ description, severity: normalizeSeverity(record.severity) })
+  }
+  return result
+}
+
+function normalizeStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter((x): x is string => typeof x === "string" && x.trim().length > 0)
+}
+
+function fallbackSynthesis(
+  classifications: CommitClassification[],
+  reason: string,
+): SynthesisResult {
+  return {
+    recommendation: "HOLD_FOR_HUMAN",
+    confidence: "low",
+    summary: `Synthesis failed (${reason}). Human review required.`,
+    slopRatioPercent: computeSlopRatio(classifications),
+    breakingChanges: [],
+    dependencyChanges: [],
+    architectureDrift: [],
+    hiddenConcerns: [],
+    actionItems: ["Synthesis pass failed; review classifications manually."],
+  }
+}
+
+export async function synthesizeRelease(input: SynthesisInput): Promise<SynthesisResult> {
+  const userPrompt = await buildUserPrompt(input)
+
+  let parsed: unknown
+  try {
+    const result = await inferJson({
+      model: input.model,
+      systemPrompt: input.systemPrompt,
+      userPrompt,
+      maxTokens: MAX_TOKENS_OUT,
+      temperature: 0.2,
+    })
+    parsed = result.parsed
+  } catch (cause) {
+    return fallbackSynthesis(input.classifications, (cause as Error).message)
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return fallbackSynthesis(input.classifications, "Synthesizer returned non-JSON")
+  }
+
+  const record = parsed as Record<string, unknown>
+  const slopRatio =
+    typeof record.slop_ratio_percent === "number"
+      ? Math.round(record.slop_ratio_percent)
+      : computeSlopRatio(input.classifications)
+
+  return {
+    recommendation: normalizeRecommendation(record.recommendation),
+    confidence:
+      record.confidence === "high" || record.confidence === "medium" || record.confidence === "low"
+        ? record.confidence
+        : "medium",
+    summary:
+      typeof record.summary === "string" ? record.summary.trim() : "No summary provided",
+    slopRatioPercent: slopRatio,
+    breakingChanges: normalizeBreakingChanges(record.breaking_changes),
+    dependencyChanges: normalizeStringArray(record.dependency_changes),
+    architectureDrift: normalizeStringArray(record.architecture_drift),
+    hiddenConcerns: normalizeStringArray(record.hidden_concerns),
+    actionItems: normalizeStringArray(record.action_items),
+  }
+}

--- a/script/upstream-analyzer/run.ts
+++ b/script/upstream-analyzer/run.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+
+import { appendFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { loadConfigFromEnv, shouldPushBranches } from "./cli-config"
+import { buildIssueBody, buildIssueLabels, buildIssueTitle, buildBatchPrBody } from "./issue-report"
+import { runPipeline } from "./pipeline"
+import type { PipelineResult } from "./pipeline"
+
+interface WorkflowArtifacts {
+  issueTitle: string
+  issueBody: string
+  issueLabels: string[]
+  batchPrSpecs: Array<{
+    batch: string
+    branchName: string
+    title: string
+    body: string
+    skipped: boolean
+  }>
+}
+
+function buildWorkflowArtifacts(result: PipelineResult): WorkflowArtifacts {
+  const issueTitle = buildIssueTitle(result.config, result.synthesis)
+  const issueBody = buildIssueBody({
+    config: result.config,
+    classifications: result.commits,
+    verifications: result.verifications,
+    synthesis: result.synthesis,
+    batches: result.batches,
+  })
+  const issueLabels = buildIssueLabels(result.synthesis, result.config.toTag)
+
+  const batchPrSpecs = result.batches.map((batch) => ({
+    batch: batch.batch,
+    branchName: batch.branchName,
+    title: `[${batch.batch}] Upstream sync ${result.config.fromTag} → ${result.config.toTag}`,
+    body: buildBatchPrBody(batch, result.commits, null),
+    skipped: batch.skipped || batch.appliedCommits.length === 0,
+  }))
+
+  return { issueTitle, issueBody, issueLabels, batchPrSpecs }
+}
+
+async function writeWorkflowArtifacts(outputDir: string, artifacts: WorkflowArtifacts): Promise<void> {
+  await writeFile(join(outputDir, "issue-title.txt"), artifacts.issueTitle, "utf8")
+  await writeFile(join(outputDir, "issue-body.md"), artifacts.issueBody, "utf8")
+  await writeFile(join(outputDir, "issue-labels.json"), JSON.stringify(artifacts.issueLabels), "utf8")
+  await writeFile(
+    join(outputDir, "batch-pr-specs.json"),
+    JSON.stringify(artifacts.batchPrSpecs, null, 2),
+    "utf8",
+  )
+}
+
+async function emitGithubOutputs(artifacts: WorkflowArtifacts): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) return
+  const lines: string[] = []
+  lines.push(`issue_title<<EOF_TITLE`, artifacts.issueTitle, `EOF_TITLE`)
+  lines.push(`issue_labels<<EOF_LABELS`, JSON.stringify(artifacts.issueLabels), `EOF_LABELS`)
+  lines.push(`batch_specs<<EOF_SPECS`, JSON.stringify(artifacts.batchPrSpecs), `EOF_SPECS`)
+  lines.push(`has_commits=${artifacts.batchPrSpecs.some((s) => !s.skipped) ? "true" : "false"}`)
+  await appendFile(outputPath, `${lines.join("\n")}\n`, "utf8")
+}
+
+async function main(): Promise<void> {
+  const config = loadConfigFromEnv()
+  const pushBranches = shouldPushBranches()
+
+  console.log("[analyzer] starting pipeline")
+  console.log(`[analyzer] upstream=${config.upstreamRepo} ${config.fromTag} -> ${config.toTag}`)
+  const verifyChain = [config.modelSlopVerify, ...config.modelSlopVerifyFallbacks].join(" -> ")
+  console.log(
+    `[analyzer] models: classify=${config.modelClassify} verify=${verifyChain} synth=${config.modelSynthesis}`,
+  )
+  console.log(`[analyzer] pushBranches=${pushBranches}`)
+
+  const result = await runPipeline({ config, pushBranches })
+  const artifacts = buildWorkflowArtifacts(result)
+  await writeWorkflowArtifacts(config.outputDir, artifacts)
+  await emitGithubOutputs(artifacts)
+
+  console.log("[analyzer] pipeline complete")
+  console.log(`[analyzer] recommendation: ${result.synthesis.recommendation}`)
+  console.log(`[analyzer] slop ratio: ${result.synthesis.slopRatioPercent}%`)
+}
+
+main().catch((err) => {
+  console.error("[analyzer] failed:", err)
+  process.exit(1)
+})

--- a/script/upstream-analyzer/slop-verifier.ts
+++ b/script/upstream-analyzer/slop-verifier.ts
@@ -1,0 +1,139 @@
+import { getCommitDiff } from "./git-inspector"
+import { inferJsonWithFallback } from "./github-models-client"
+import type {
+  CommitClassification,
+  CommitVerdict,
+  SlopVerification,
+  SlopVerifyVerdict,
+} from "./types"
+
+const MAX_TOKENS_OUT = 768
+
+// gpt-5-mini caps input at ~4K tokens on Copilot Pro/Student tier, so we keep
+// verifier diff payloads much smaller than the pass-1 classifier. The fallback
+// chain (gpt-4.1 / gpt-4.1-mini) has higher headroom (8K tokens), so larger
+// payloads still fit there if gpt-5-mini quota is exhausted.
+const MAX_DIFF_CHARS = 10000
+
+function buildUserPrompt(classification: CommitClassification, diff: string): string {
+  return [
+    `Commit: ${classification.shortSha}`,
+    `Subject: ${classification.subject}`,
+    `First-pass verdict: SLOP (confidence: ${classification.confidence})`,
+    `First-pass reason: ${classification.reason}`,
+    `First-pass slop signals: ${classification.slopSignals.join(", ") || "(none)"}`,
+    "",
+    "Full diff:",
+    diff,
+  ].join("\n")
+}
+
+function normalizeVerdict(raw: unknown): SlopVerifyVerdict {
+  if (raw === "CONFIRMED_SLOP" || raw === "DEMOTE_TO_REVIEW" || raw === "DEMOTE_TO_GOOD") {
+    return raw
+  }
+  return "DEMOTE_TO_REVIEW"
+}
+
+function normalizeBehaviorDelta(raw: unknown): "none" | "minor" | "significant" {
+  if (raw === "none" || raw === "minor" || raw === "significant") return raw
+  return "none"
+}
+
+function applyVerdict(result: SlopVerifyVerdict): CommitVerdict {
+  if (result === "CONFIRMED_SLOP") return "SLOP"
+  if (result === "DEMOTE_TO_GOOD") return "GOOD"
+  return "NEEDS_REVIEW"
+}
+
+function fallbackVerification(classification: CommitClassification, reason: string): SlopVerification {
+  return {
+    sha: classification.sha,
+    originalVerdict: classification.verdict,
+    finalVerdict: classification.verdict,
+    verifyResult: "CONFIRMED_SLOP",
+    reasoning: `Verification failed, keeping original verdict: ${reason}`,
+    behaviorDelta: "none",
+  }
+}
+
+export interface SlopVerifyModels {
+  primary: string
+  fallbacks: string[]
+}
+
+export async function verifySlopCommit(
+  classification: CommitClassification,
+  systemPrompt: string,
+  models: SlopVerifyModels,
+): Promise<SlopVerification> {
+  const diff = await getCommitDiff(classification.sha, MAX_DIFF_CHARS)
+
+  let parsed: unknown
+  try {
+    const result = await inferJsonWithFallback({
+      primaryModel: models.primary,
+      fallbackModels: models.fallbacks,
+      systemPrompt,
+      userPrompt: buildUserPrompt(classification, diff),
+      maxTokens: MAX_TOKENS_OUT,
+      temperature: 0.2,
+      onFallback: (failed, next, reason) => {
+        console.warn(`[verifier] ${classification.shortSha}: ${failed} failed (${reason}); trying ${next}`)
+      },
+    })
+    parsed = result.parsed
+  } catch (cause) {
+    return fallbackVerification(classification, (cause as Error).message)
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return fallbackVerification(classification, "Verifier returned non-JSON")
+  }
+
+  const record = parsed as Record<string, unknown>
+  const verifyResult = normalizeVerdict(record.verdict)
+  const reasoning =
+    typeof record.reasoning === "string" ? record.reasoning.trim() : "No reasoning provided"
+
+  return {
+    sha: classification.sha,
+    originalVerdict: classification.verdict,
+    finalVerdict: applyVerdict(verifyResult),
+    verifyResult,
+    reasoning,
+    behaviorDelta: normalizeBehaviorDelta(record.behavior_delta),
+  }
+}
+
+export async function verifySlopCommits(
+  classifications: CommitClassification[],
+  systemPrompt: string,
+  models: SlopVerifyModels,
+): Promise<SlopVerification[]> {
+  const slopCandidates = classifications.filter((c) => c.verdict === "SLOP")
+  const results: SlopVerification[] = []
+  for (const candidate of slopCandidates) {
+    results.push(await verifySlopCommit(candidate, systemPrompt, models))
+  }
+  return results
+}
+
+export function applyVerificationsToClassifications(
+  classifications: CommitClassification[],
+  verifications: SlopVerification[],
+): CommitClassification[] {
+  const byVerifiedSha = new Map(verifications.map((v) => [v.sha, v]))
+  return classifications.map((c) => {
+    const verified = byVerifiedSha.get(c.sha)
+    if (!verified) return c
+    return {
+      ...c,
+      verdict: verified.finalVerdict,
+      reason:
+        verified.finalVerdict === c.verdict
+          ? c.reason
+          : `${c.reason} | Verifier: ${verified.reasoning}`,
+    }
+  })
+}

--- a/script/upstream-analyzer/types.ts
+++ b/script/upstream-analyzer/types.ts
@@ -1,0 +1,64 @@
+export type CommitVerdict = "GOOD" | "NEEDS_REVIEW" | "SLOP"
+
+export type SlopVerifyVerdict = "CONFIRMED_SLOP" | "DEMOTE_TO_REVIEW" | "DEMOTE_TO_GOOD"
+
+export type SynthesisRecommendation = "MERGE_CLEAN" | "CHERRY_PICK" | "SKIP" | "HOLD_FOR_HUMAN"
+
+export interface CommitMeta {
+  sha: string
+  shortSha: string
+  subject: string
+  author: string
+  date: string
+}
+
+export interface CommitClassification {
+  sha: string
+  shortSha: string
+  subject: string
+  verdict: CommitVerdict
+  confidence: "high" | "medium" | "low"
+  reason: string
+  slopSignals: string[]
+}
+
+export interface SlopVerification {
+  sha: string
+  originalVerdict: CommitVerdict
+  finalVerdict: CommitVerdict
+  verifyResult: SlopVerifyVerdict
+  reasoning: string
+  behaviorDelta: "none" | "minor" | "significant"
+}
+
+export interface SynthesisResult {
+  recommendation: SynthesisRecommendation
+  confidence: "high" | "medium" | "low"
+  summary: string
+  slopRatioPercent: number
+  breakingChanges: Array<{ description: string; severity: "high" | "medium" | "low" }>
+  dependencyChanges: string[]
+  architectureDrift: string[]
+  hiddenConcerns: string[]
+  actionItems: string[]
+}
+
+export interface AnalyzerConfig {
+  upstreamRepo: string
+  fromTag: string
+  toTag: string
+  modelClassify: string
+  modelSlopVerify: string
+  modelSlopVerifyFallbacks: string[]
+  modelSynthesis: string
+  repoOwner: string
+  repoName: string
+  outputDir: string
+}
+
+export interface PipelineOutput {
+  config: AnalyzerConfig
+  commits: CommitClassification[]
+  verifications: SlopVerification[]
+  synthesis: SynthesisResult
+}


### PR DESCRIPTION
## Summary

Adds a 3-pass AI pipeline that classifies every commit in an upstream release window (GOOD / NEEDS_REVIEW / SLOP), cherry-picks each batch onto its own branch, and opens one draft PR per non-empty batch. **Phase 1 posture: advisory only. No auto-merge. No auto-publish.**

Replaces the auto-scheduling on `sync-upstream.yml` (now gated behind a typed confirmation input, kept for reference).

## Architecture

```
upstream pushes v3.17.5
        ↓
[cron */15] upstream-tag-watcher.yml
   • polls `git ls-remote` on upstream
   • compares to upstream-version.txt / .upstream-watcher-seen-tag
   • fires repository_dispatch('upstream-tag-detected', {from_tag, to_tag})
        ↓
upstream-analyzer.yml
   Pass 1: gpt-4.1-mini classifies each commit (150 req/day budget)
   Pass 2: gpt-5-mini verifies SLOP candidates (12 req/day) → falls back
           to gpt-4.1 → gpt-4.1-mini on 429/quota/context errors
   Pass 3: gpt-4.1 synthesizes release recommendation (50 req/day)
        ↓
   • Cherry-picks to sync/upstream-<tag>-{good|needs-review|slop}
   • Opens 1 analysis issue (labels: cost-benefit, upstream-review,
     upstream:<verdict>, upstream-tag:<tag>)
   • Opens up to 3 draft PRs (labels: upstream-sync, batch:<verdict>,
     upstream-tag:<tag>)
   • Uploads classifications.json / verifications.json / synthesis.json
     / batches.json as workflow artifacts
```

## Fallback semantics

The new \`inferJsonWithFallback\` in \`github-models-client.ts\` detects 429 (rate limit), 403 with rate-limit body, and 400 context-length errors, then walks a model chain. Default verifier chain:

\`\`\`
openai/gpt-5-mini  →  openai/gpt-4.1  →  openai/gpt-4.1-mini
\`\`\`

Any of these can be overridden via \`workflow_dispatch\` inputs (\`model_slop_verify\` and \`model_slop_verify_fallbacks\`).

The verifier truncates diffs to 10K chars (gpt-5-mini caps at ~4K input tokens on Copilot Pro/Student tier; fallback models tolerate larger payloads).

## Phase 1 posture: what's blocked

| Workflow | Status | Mechanism |
|---|---|---|
| sync-upstream.yml (auto-rebase) | DISABLED | scheduled trigger removed; \`workflow_dispatch\` requires typed input \`yes-legacy-force-sync\` |
| publish.yml | UNTOUCHED | already manual-only (\`workflow_dispatch\`) |
| analyzer auto-merge | NOT WIRED | all PRs land as \`draft\` |

No upstream commits can be lost: every commit is either cherry-picked into some batch branch or recorded in \`batches.json\`'s \`conflictCommits\` when cherry-pick fails.

## Files

**New**
- \`.github/prompts/commit-classify.md\` — blunt/skeptical per-commit rubric
- \`.github/prompts/slop-verify.md\` — second-pass verifier rubric
- \`.github/prompts/release-synthesis.md\` — cost-benefit synthesizer rubric
- \`.github/workflows/upstream-tag-watcher.yml\` — cron pseudo-webhook
- \`.github/workflows/upstream-analyzer.yml\` — main pipeline
- \`script/upstream-analyzer/\` — 13 TypeScript modules (types, git-inspector, github-models-client, prompt-loader, commit-classifier, slop-verifier, release-synthesizer, batch-builder, issue-report, pipeline, cli-config, run, index)

**Modified**
- \`.github/workflows/sync-upstream.yml\` — scheduled trigger removed, gated behind typed confirmation input; pre-existing SC2129 fixed while here

## Verification

- \`bun run typecheck\`: clean
- \`actionlint\`: clean on all 3 affected workflows
- Smoke test: \`bun run script/upstream-analyzer/run.ts\` loads all imports and fails at the expected env-var check

## Testing plan

Merge this PR to \`dev\`, then from the Actions UI manually trigger **Upstream Analyzer** with:

- \`from_tag\`: \`v3.17.0\` (currently recorded in \`upstream-version.txt\`)
- \`to_tag\`: \`v3.17.4\` (current latest upstream)
- \`push_branches\`: \`true\`

Expected output:
- 1 issue with cost-benefit report
- Up to 3 draft PRs (good / needs-review / slop batches, whichever have commits)
- Workflow artifact \`analyzer-output-v3.17.4\` with all JSON

If the pipeline proves useful on this first run, we'll tune the prompts and consider flipping to Phase 2 (auto-merge GOOD batch on \`MERGE_CLEAN\` verdict).

## Out of scope

- Auto-merge of the good batch → Phase 2
- Auto-publish on clean releases → Phase 2
- Integration with \`sisyphus-agent.yml\` (kept independent for now)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 3-pass upstream release analyzer that classifies commits (GOOD / NEEDS_REVIEW / SLOP), cherry-picks them into batch branches, and opens draft PRs per batch. Disables the scheduled legacy sync; Phase 1 is advisory only (no auto-merge or publish).

**New Features**
- `upstream-tag-watcher.yml` polls `code-yeongyu/oh-my-openagent` for new stable tags and dispatches analysis.
- `upstream-analyzer.yml` runs 3 passes: per-commit classify (`openai/gpt-4.1-mini`), SLOP verify with fallback (`openai/gpt-5-mini` → `openai/gpt-4.1` → `openai/gpt-4.1-mini`), and release synthesis (`openai/gpt-4.1`).
- Produces one analysis issue, up to 3 draft PRs for `sync/upstream-<tag>-{good|needs-review|slop}`, and uploads JSON artifacts.
- Prompts live in `.github/prompts/`; scripts live in `script/upstream-analyzer/`. Conflicting cherry-picks are logged in `batches.json`.

**Migration**
- Legacy `Sync Upstream` is disabled and only runs with the typed input `yes-legacy-force-sync`.
- To try the new flow: Actions → Upstream Analyzer; set `from_tag`, `to_tag`, and `push_branches: true`. Expect one analysis issue and up to 3 draft PRs.

<sup>Written for commit 7626cd72fc174e6f7a1ab2ef7f5336be20ae9f79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

