### PR TITLE
fix(ci): drop --frozen-lockfile from upstream-analyzer install

### DIFF
--- a/.github/workflows/upstream-analyzer.yml
+++ b/.github/workflows/upstream-analyzer.yml
@@ -130,7 +130,7 @@ jobs:
           bun-version: "1.3.11"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
         env:
           BUN_INSTALL_ALLOW_SCRIPTS: "@ast-grep/napi"
 


### PR DESCRIPTION
## Summary

First real run of the analyzer failed at install:

\`\`\`
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
\`\`\`

## Fix

Match house style. Every other workflow in the repo uses plain \`bun install\`:

| Workflow | Install command |
|---|---|
| ci.yml | \`bun install\` |
| publish.yml | \`bun install\` |
| refresh-model-capabilities.yml | \`bun install\` |
| sisyphus-agent.yml | \`bun install\` |
| upstream-analyzer.yml (before) | \`bun install --frozen-lockfile\` ← out of step |
| upstream-analyzer.yml (after) | \`bun install\` |

The lockfile drift itself is pre-existing repo state, unrelated to the analyzer feature.

## Verification

Actionlint clean. Next analyzer run will hit this fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the upstream-analyzer workflow to use plain `bun install` instead of `bun install --frozen-lockfile`. This matches other workflows and prevents install failures caused by pre-existing lockfile drift.

<sup>Written for commit f4f71f7cb9b046ca7767b046dd88a1e1d03d6133. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

