### PR TITLE
fix(analyzer): force-fetch upstream tags to tolerate fork history rewrites

### DIFF
--- a/script/upstream-analyzer/git-inspector.ts
+++ b/script/upstream-analyzer/git-inspector.ts
@@ -6,7 +6,11 @@ const DEFAULT_DIFF_CHARS = 24000
 export async function ensureUpstreamRemote(upstreamRepo: string): Promise<void> {
   await $`git remote remove upstream`.quiet().nothrow()
   await $`git remote add upstream https://github.com/${upstreamRepo}.git`.quiet()
-  await $`git fetch --tags upstream`.quiet()
+  // --force: upstream wins when its tag SHA differs from the fork's. Forks
+  // sometimes rewrite tag history during sync; without --force the fetch
+  // exits non-zero and the whole pipeline aborts. The CI clone is ephemeral
+  // and never pushed, so overwriting local tags here is safe.
+  await $`git fetch --force --tags upstream`.quiet()
 }
 
 export async function tagExists(tag: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

First real analyzer run failed at \`ensureUpstreamRemote\` — the fork has rewritten history at \`v3.17.2\` (different SHA than upstream's), so \`git fetch --tags upstream\` exits non-zero:

\`\`\`
! [rejected] v3.17.2 -> v3.17.2 (would clobber existing tag)
\`\`\`

Most tags fetch successfully, but the ShellError aborts the pipeline before pass 1 even starts.

## Fix

Add \`--force\` to the tag fetch. The CI runner is ephemeral and never pushes — overwriting the clone's local tag pointers is scoped to that single job.

## Why this is safe

- The fork's actual refs on origin are untouched (no push happens in this workflow)
- Only upstream SHAs are honored anyway (we're analyzing **upstream** commits, not our own)
- The runner is discarded after the job completes

## Verification

- \`bun run typecheck\` clean
- Pattern matches how every other forked-repo analysis workflow handles upstream tags
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force-fetch upstream tags in the analyzer to handle fork tag history rewrites and stop early pipeline aborts.

- **Bug Fixes**
  - In `ensureUpstreamRemote`, switch `git fetch --tags upstream` to `git fetch --force --tags upstream`.
  - Prevents non-zero exits when fork tag SHAs differ from upstream. Safe in ephemeral CI (no pushes; analyzer only uses upstream SHAs).

<sup>Written for commit 04359d4a14f64a6e6aeb95eb8a4762ef1f35dc1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

