### PR TITLE
fix(analyzer): rate limiting, tree reset, and partial persistence

### DIFF
--- a/script/upstream-analyzer/commit-classifier.ts
+++ b/script/upstream-analyzer/commit-classifier.ts
@@ -1,8 +1,12 @@
 import { getCommitDiff } from "./git-inspector"
 import { inferJson } from "./github-models-client"
+import { RateLimiter } from "./throttle"
 import type { CommitClassification, CommitMeta, CommitVerdict } from "./types"
 
 const MAX_TOKENS_OUT = 512
+// Copilot Student / Pro tier caps low-tier models at 15 req/min. Stay
+// below that so pass 1 does not cliff-edge into 429s mid-run.
+const DEFAULT_REQUESTS_PER_MINUTE = 12
 
 function buildUserPrompt(commit: CommitMeta, diff: string): string {
   return [
@@ -85,17 +89,26 @@ export async function classifyCommit(
   }
 }
 
+export interface ClassifySequentiallyOptions {
+  commits: CommitMeta[]
+  systemPrompt: string
+  model: string
+  requestsPerMinute?: number
+  onProgress?: (index: number, total: number, classification: CommitClassification) => void
+}
+
 export async function classifyCommitsSequentially(
-  commits: CommitMeta[],
-  systemPrompt: string,
-  model: string,
-  onProgress?: (index: number, total: number, classification: CommitClassification) => void,
+  options: ClassifySequentiallyOptions,
 ): Promise<CommitClassification[]> {
+  const limiter = new RateLimiter({
+    requestsPerMinute: options.requestsPerMinute ?? DEFAULT_REQUESTS_PER_MINUTE,
+  })
   const results: CommitClassification[] = []
-  for (let i = 0; i < commits.length; i++) {
-    const classification = await classifyCommit(commits[i], systemPrompt, model)
+  for (let i = 0; i < options.commits.length; i++) {
+    await limiter.throttle()
+    const classification = await classifyCommit(options.commits[i], options.systemPrompt, options.model)
     results.push(classification)
-    onProgress?.(i + 1, commits.length, classification)
+    options.onProgress?.(i + 1, options.commits.length, classification)
   }
   return results
 }

--- a/script/upstream-analyzer/git-inspector.ts
+++ b/script/upstream-analyzer/git-inspector.ts
@@ -48,6 +48,17 @@ export async function getDependencyChanges(fromTag: string, toTag: string): Prom
   return result.text()
 }
 
+export async function resetWorkingTree(): Promise<void> {
+  // `bun install` without --frozen-lockfile may modify bun.lock, which
+  // blocks subsequent `git checkout -b` with "local changes would be
+  // overwritten". Reset discards every uncommitted modification in the
+  // ephemeral CI clone so the batch-build phase starts from a clean slate.
+  // --hard HEAD: throw away tracked file changes. -fdx: remove untracked
+  // files and ignored files (node_modules, .analyzer-output, etc).
+  await $`git reset --hard HEAD`.quiet().nothrow()
+  await $`git clean -fdx -e .analyzer-output`.quiet().nothrow()
+}
+
 export async function createBranchFromTag(branchName: string, baseTag: string): Promise<void> {
   await $`git branch -D ${branchName}`.quiet().nothrow()
   await $`git checkout -b ${branchName} ${baseTag}`.quiet()

--- a/script/upstream-analyzer/pipeline.ts
+++ b/script/upstream-analyzer/pipeline.ts
@@ -4,7 +4,12 @@ import { buildAllBatches, pushBatches } from "./batch-builder"
 import type { BatchResult } from "./batch-builder"
 import { applyVerificationsToClassifications, verifySlopCommits } from "./slop-verifier"
 import { classifyCommitsSequentially } from "./commit-classifier"
-import { ensureUpstreamRemote, listCommitsInRange, tagExists } from "./git-inspector"
+import {
+  ensureUpstreamRemote,
+  listCommitsInRange,
+  resetWorkingTree,
+  tagExists,
+} from "./git-inspector"
 import { loadAllPrompts } from "./prompt-loader"
 import { synthesizeRelease } from "./release-synthesizer"
 import type {
@@ -45,8 +50,13 @@ async function runPass1Classify(
     logProgress("pass1", "no commits in range, nothing to do")
     return []
   }
-  return classifyCommitsSequentially(commits, systemPrompt, config.modelClassify, (i, n, c) => {
-    logProgress("pass1", `${i}/${n} ${c.shortSha} => ${c.verdict}`)
+  return classifyCommitsSequentially({
+    commits,
+    systemPrompt,
+    model: config.modelClassify,
+    onProgress: async (i, n, classification) => {
+      logProgress("pass1", `${i}/${n} ${classification.shortSha} => ${classification.verdict}`)
+    },
   })
 }
 
@@ -90,6 +100,8 @@ async function runBatchBuilding(
   config: AnalyzerConfig,
   classifications: CommitClassification[],
 ): Promise<BatchResult[]> {
+  logProgress("batches", "resetting working tree before checkout")
+  await resetWorkingTree()
   logProgress("batches", "building good / review / slop branches")
   const results = await buildAllBatches({
     fromTag: config.fromTag,
@@ -129,17 +141,30 @@ export interface PipelineResult extends PipelineOutput {
 }
 
 export async function runPipeline(options: PipelineRunOptions): Promise<PipelineResult> {
+  const { outputDir } = options.config
   const prompts = await loadAllPrompts()
   await prepareUpstreamRange(options.config)
 
+  // Persist after every pass so partial progress survives any downstream
+  // failure. The CI workflow uploads outputDir unconditionally, so even a
+  // pipeline crash produces useful post-mortem artifacts.
   const initialClassifications = await runPass1Classify(options.config, prompts.commitClassify)
+  await writeArtifact(outputDir, "classifications.initial.json", initialClassifications)
+
   const { verifications, final } = await runPass2Verify(
     options.config,
     initialClassifications,
     prompts.slopVerify,
   )
+  await writeArtifact(outputDir, "verifications.json", verifications)
+  await writeArtifact(outputDir, "classifications.json", final)
+
   const synthesis = await runPass3Synthesize(options.config, final, prompts.releaseSynthesis)
+  await writeArtifact(outputDir, "synthesis.json", synthesis)
+
   const batches = await runBatchBuilding(options.config, final)
+  await writeArtifact(outputDir, "batches.json", batches)
+
   await pushIfRequested(batches, options.pushBranches)
 
   const result: PipelineResult = {
@@ -150,11 +175,6 @@ export async function runPipeline(options: PipelineRunOptions): Promise<Pipeline
     batches,
   }
 
-  await writeArtifact(options.config.outputDir, "classifications.json", final)
-  await writeArtifact(options.config.outputDir, "verifications.json", verifications)
-  await writeArtifact(options.config.outputDir, "synthesis.json", synthesis)
-  await writeArtifact(options.config.outputDir, "batches.json", batches)
-  await writeArtifact(options.config.outputDir, "pipeline-result.json", result)
-
+  await writeArtifact(outputDir, "pipeline-result.json", result)
   return result
 }

--- a/script/upstream-analyzer/throttle.ts
+++ b/script/upstream-analyzer/throttle.ts
@@ -1,0 +1,24 @@
+export interface RateLimiterOptions {
+  requestsPerMinute: number
+}
+
+export class RateLimiter {
+  private readonly minIntervalMs: number
+  private nextAllowedAt = 0
+
+  constructor(options: RateLimiterOptions) {
+    if (options.requestsPerMinute <= 0) {
+      throw new Error(`requestsPerMinute must be > 0, got ${options.requestsPerMinute}`)
+    }
+    this.minIntervalMs = Math.ceil(60_000 / options.requestsPerMinute)
+  }
+
+  async throttle(): Promise<void> {
+    const now = Date.now()
+    const waitMs = this.nextAllowedAt - now
+    if (waitMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, waitMs))
+    }
+    this.nextAllowedAt = Date.now() + this.minIntervalMs
+  }
+}


### PR DESCRIPTION
## Summary

Three real failures surfaced in the first end-to-end analyzer run (v3.17.0 → v3.17.4, 116 commits). Fixing all three.

## 1. Rate limiting on pass 1

Copilot Student / Pro tier caps low-tier models (\`gpt-4.1-mini\`) at **15 req/min**. The first run blew through the limit at request #15 — commits 16-116 returned instant 429 fallbacks with no real classification:

\`\`\`
pass1: 15/116 b0b19f30 => GOOD      (1.5s, real inference)
pass1: 16/116 314e1a5e => NEEDS_REVIEW   (0.1s, 429 fallback)
pass1: 17/116 d21ed3f7 => NEEDS_REVIEW   (0.1s, 429 fallback)
... all remaining 100 commits: same 0.1s fallback pattern
\`\`\`

Fix: new \`RateLimiter\` (\`script/upstream-analyzer/throttle.ts\`) with simple interval throttling. Default **12 rpm** — comfortably below the 15 rpm ceiling.

## 2. Dirty working tree blocked batch-builder

\`bun install\` without \`--frozen-lockfile\` modifies \`bun.lock\`. Then \`git checkout -b\` refuses:

\`\`\`
error: Your local changes to the following files would be overwritten by checkout:
	bun.lock
Please commit your changes or stash them before you switch branches.
\`\`\`

Fix: new \`resetWorkingTree()\` — \`git reset --hard HEAD\` + \`git clean -fdx -e .analyzer-output\`. Called before batch building. Safe because the CI clone is ephemeral and never pushed. \`.analyzer-output\` excluded so pass artifacts survive.

## 3. Crashes lost all partial progress

When the pipeline failed mid-run, artifact upload found no files (\`.analyzer-output/\` was empty — writes happened only at the end). Fix: \`runPipeline\` now \`writeArtifact\`s after each pass:

| After pass | Artifact |
|---|---|
| Pass 1 | \`classifications.initial.json\` |
| Pass 2 | \`classifications.json\` + \`verifications.json\` |
| Pass 3 | \`synthesis.json\` |
| Batch builder | \`batches.json\` |
| End | \`pipeline-result.json\` |

Combined with \`if: always()\` on the existing upload step, this guarantees post-mortem data even on crash.

## API change

\`classifyCommitsSequentially\` signature changed from positional to options object — needed to add optional \`requestsPerMinute\` without threading boilerplate. Breaking only for this single internal call site, already updated.

## Verification

- \`bun run typecheck\` — clean
- LSP diagnostics — clean on all 14 files in \`script/upstream-analyzer/\`
- Expected behavior on next analyzer run:
  - Pass 1 on 116 commits takes ~10 min (vs 40 sec before with 100 bogus fallbacks)
  - Every crash leaves useful artifacts for debugging
  - Batch builder no longer fails at checkout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three analyzer failures: avoids 429s in pass 1 with request throttling, prevents batch-building checkout errors by resetting the working tree, and saves artifacts after each pass so crashes keep partial results.

- **Bug Fixes**
  - Added `RateLimiter` (12 rpm default) and updated `classifyCommitsSequentially` to an options signature to support rpm and progress callbacks.
  - Reset working tree before batch building (`git reset --hard` + `git clean -fdx -e .analyzer-output`) to avoid checkout failures.
  - Persist artifacts after each step (`classifications.initial.json`, `verifications.json`, `classifications.json`, `synthesis.json`, `batches.json`, then `pipeline-result.json`) for reliable crash recovery.

<sup>Written for commit 3c6941e09fd1f86247dcc13698b6c2e94586f897. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

