### PR TITLE
fix(analyzer): write artifacts outside git worktree (use runner.temp)

### DIFF
--- a/.github/workflows/upstream-analyzer.yml
+++ b/.github/workflows/upstream-analyzer.yml
@@ -145,7 +145,7 @@ jobs:
           MODEL_SLOP_VERIFY_FALLBACKS: ${{ steps.inputs.outputs.model_slop_verify_fallbacks }}
           MODEL_SYNTHESIS: ${{ steps.inputs.outputs.model_synthesis }}
           PUSH_BRANCHES: ${{ steps.inputs.outputs.push_branches }}
-          OUTPUT_DIR: .analyzer-output
+          OUTPUT_DIR: ${{ runner.temp }}/analyzer-output
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run script/upstream-analyzer/run.ts
 
@@ -154,18 +154,22 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: analyzer-output-${{ steps.inputs.outputs.to_tag }}
-          path: .analyzer-output/
+          path: ${{ runner.temp }}/analyzer-output/
           retention-days: 30
 
       - name: Create analysis issue
         id: issue
         uses: actions/github-script@v7
+        env:
+          OUTPUT_DIR: ${{ runner.temp }}/analyzer-output
         with:
           script: |
             const fs = require('node:fs/promises');
-            const title = (await fs.readFile('.analyzer-output/issue-title.txt', 'utf8')).trim();
-            const body = await fs.readFile('.analyzer-output/issue-body.md', 'utf8');
-            const labels = JSON.parse(await fs.readFile('.analyzer-output/issue-labels.json', 'utf8'));
+            const path = require('node:path');
+            const outputDir = process.env.OUTPUT_DIR;
+            const title = (await fs.readFile(path.join(outputDir, 'issue-title.txt'), 'utf8')).trim();
+            const body = await fs.readFile(path.join(outputDir, 'issue-body.md'), 'utf8');
+            const labels = JSON.parse(await fs.readFile(path.join(outputDir, 'issue-labels.json'), 'utf8'));
 
             const response = await github.rest.issues.create({
               owner: context.repo.owner,
@@ -183,10 +187,13 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
           TO_TAG: ${{ steps.inputs.outputs.to_tag }}
+          OUTPUT_DIR: ${{ runner.temp }}/analyzer-output
         with:
           script: |
             const fs = require('node:fs/promises');
-            const specs = JSON.parse(await fs.readFile('.analyzer-output/batch-pr-specs.json', 'utf8'));
+            const path = require('node:path');
+            const outputDir = process.env.OUTPUT_DIR;
+            const specs = JSON.parse(await fs.readFile(path.join(outputDir, 'batch-pr-specs.json'), 'utf8'));
             const issueNumber = Number(process.env.ISSUE_NUMBER);
 
             for (const spec of specs) {

--- a/.github/workflows/upstream-analyzer.yml
+++ b/.github/workflows/upstream-analyzer.yml
@@ -125,6 +125,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Export analyzer output dir
+        run: echo "ANALYZER_OUTPUT_DIR=${RUNNER_TEMP}/analyzer-output" >> "$GITHUB_ENV"
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
@@ -145,7 +148,7 @@ jobs:
           MODEL_SLOP_VERIFY_FALLBACKS: ${{ steps.inputs.outputs.model_slop_verify_fallbacks }}
           MODEL_SYNTHESIS: ${{ steps.inputs.outputs.model_synthesis }}
           PUSH_BRANCHES: ${{ steps.inputs.outputs.push_branches }}
-          OUTPUT_DIR: ${{ runner.temp }}/analyzer-output
+          OUTPUT_DIR: ${{ env.ANALYZER_OUTPUT_DIR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run script/upstream-analyzer/run.ts
 
@@ -154,19 +157,23 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: analyzer-output-${{ steps.inputs.outputs.to_tag }}
-          path: ${{ runner.temp }}/analyzer-output/
+          path: ${{ env.ANALYZER_OUTPUT_DIR }}/
           retention-days: 30
 
       - name: Create analysis issue
         id: issue
         uses: actions/github-script@v7
         env:
-          OUTPUT_DIR: ${{ runner.temp }}/analyzer-output
+          OUTPUT_DIR: ${{ env.ANALYZER_OUTPUT_DIR }}
         with:
           script: |
             const fs = require('node:fs/promises');
             const path = require('node:path');
             const outputDir = process.env.OUTPUT_DIR;
+            if (!outputDir) {
+              core.setFailed('OUTPUT_DIR env var is empty. Check job-level ANALYZER_OUTPUT_DIR wiring.');
+              return;
+            }
             const title = (await fs.readFile(path.join(outputDir, 'issue-title.txt'), 'utf8')).trim();
             const body = await fs.readFile(path.join(outputDir, 'issue-body.md'), 'utf8');
             const labels = JSON.parse(await fs.readFile(path.join(outputDir, 'issue-labels.json'), 'utf8'));
@@ -187,12 +194,16 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ steps.issue.outputs.issue_number }}
           TO_TAG: ${{ steps.inputs.outputs.to_tag }}
-          OUTPUT_DIR: ${{ runner.temp }}/analyzer-output
+          OUTPUT_DIR: ${{ env.ANALYZER_OUTPUT_DIR }}
         with:
           script: |
             const fs = require('node:fs/promises');
             const path = require('node:path');
             const outputDir = process.env.OUTPUT_DIR;
+            if (!outputDir) {
+              core.setFailed('OUTPUT_DIR env var is empty. Check job-level ANALYZER_OUTPUT_DIR wiring.');
+              return;
+            }
             const specs = JSON.parse(await fs.readFile(path.join(outputDir, 'batch-pr-specs.json'), 'utf8'));
             const issueNumber = Number(process.env.ISSUE_NUMBER);
 


### PR DESCRIPTION
## Summary

Fifth analyzer run completed **the entire pipeline** (passes 1-3 + batch building + pushing 2 of 3 batches to origin) but upload-artifact reported:

\`\`\`
No files were found with the provided path: .analyzer-output/.
\`\`\`

## Root cause

The analyzer writes artifacts to the repo-rooted \`.analyzer-output/\` directory. The batch-builder phase runs \`git checkout -b <branch> <baseTag>\` three times (once per verdict), switching HEAD between branches rooted at the upstream \`v3.17.0\` tag.

Under some combination of bun's shell CWD handling and git-checkout edge cases, the untracked \`.analyzer-output/\` directory was lost between the writes and the upload step.

## Fix

Use \`\${{ runner.temp }}/analyzer-output\` for both \`OUTPUT_DIR\` env var and the upload/read paths. \`runner.temp\` is outside the git worktree, so git operations cannot affect it.

All three consuming steps updated:
- \`Run analyzer pipeline\` (\`OUTPUT_DIR\` env)
- \`Upload analyzer artifacts\` (\`path\`)
- \`Create analysis issue\` (read via \`OUTPUT_DIR\` env)
- \`Open draft PRs for batches\` (read via \`OUTPUT_DIR\` env)

## Also

Enabled Issues on \`Vacbo/oh-my-opencode\` (was disabled, causing \`Create analysis issue\` to fail with \`HttpError: Issues has been disabled in this repository\`). Done via:
\`\`\`
gh api -X PATCH repos/Vacbo/oh-my-opencode -f has_issues=true
\`\`\`

## Verification

- Actionlint clean on the modified workflow
- No TypeScript changes, no typecheck impact
- Expected on next run: artifacts upload successfully, issue is created, draft PRs open for the 2 pushable batches (needs-review, slop)

The good batch push will still be blocked by the workflow-permission rule; its status will be surfaced in the issue body as designed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write analyzer artifacts to `${{ runner.temp }}/analyzer-output` so git checkouts can’t delete them. Centralized the path and added env guards so uploads, issue creation, and batch PR steps can read files reliably.

- **Bug Fixes**
  - Set `OUTPUT_DIR` to `${{ runner.temp }}/analyzer-output` and export `ANALYZER_OUTPUT_DIR` to `$GITHUB_ENV`, then use `${{ env.ANALYZER_OUTPUT_DIR }}` across all steps.
  - Updated artifact upload and `github-script` steps to read via `OUTPUT_DIR` with `path.join`, with checks that fail the job if `OUTPUT_DIR` is unset.

<sup>Written for commit 28569f46b9cdad61164cdbe8239d232e77486573. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

