### PR TITLE
feat(analyzer): lead chains with best free models, GitHub last

### DIFF
--- a/.github/workflows/upstream-analyzer.yml
+++ b/.github/workflows/upstream-analyzer.yml
@@ -48,17 +48,17 @@ on:
       classify_chain:
         description: "Comma-separated provider:model chain for pass 1 (per-commit classify)"
         required: false
-        default: "github:openai/gpt-4.1-mini,openrouter:qwen/qwen3-coder:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1"
+        default: "openrouter:qwen/qwen3-coder:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1-mini"
         type: string
       slop_verify_chain:
         description: "Comma-separated provider:model chain for pass 2 (slop verification)"
         required: false
-        default: "nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,openrouter:nvidia/nemotron-3-super-120b-a12b:free,github:openai/gpt-4.1"
+        default: "openrouter:nvidia/nemotron-3-super-120b-a12b:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
         type: string
       synthesis_chain:
         description: "Comma-separated provider:model chain for pass 3 (release synthesis)"
         required: false
-        default: "openrouter:qwen/qwen3-next-80b-a3b-instruct:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
+        default: "openrouter:nvidia/nemotron-3-super-120b-a12b:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
         type: string
 
 concurrency:
@@ -100,9 +100,9 @@ jobs:
           TO_TAG="${INPUT_TO:-$DISPATCH_TO}"
           UPSTREAM_REPO="${INPUT_REPO:-${DISPATCH_REPO:-code-yeongyu/oh-my-openagent}}"
           PUSH_BRANCHES="${INPUT_PUSH:-true}"
-          CLASSIFY_CHAIN_DEFAULT="github:openai/gpt-4.1-mini,openrouter:qwen/qwen3-coder:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1"
-          SLOP_VERIFY_CHAIN_DEFAULT="nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,openrouter:nvidia/nemotron-3-super-120b-a12b:free,github:openai/gpt-4.1"
-          SYNTHESIS_CHAIN_DEFAULT="openrouter:qwen/qwen3-next-80b-a3b-instruct:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
+          CLASSIFY_CHAIN_DEFAULT="openrouter:qwen/qwen3-coder:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1-mini"
+          SLOP_VERIFY_CHAIN_DEFAULT="openrouter:nvidia/nemotron-3-super-120b-a12b:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
+          SYNTHESIS_CHAIN_DEFAULT="openrouter:nvidia/nemotron-3-super-120b-a12b:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
           CLASSIFY_CHAIN="${INPUT_CLASSIFY_CHAIN:-$CLASSIFY_CHAIN_DEFAULT}"
           SLOP_VERIFY_CHAIN="${INPUT_SLOP_VERIFY_CHAIN:-$SLOP_VERIFY_CHAIN_DEFAULT}"
           SYNTHESIS_CHAIN="${INPUT_SYNTHESIS_CHAIN:-$SYNTHESIS_CHAIN_DEFAULT}"

--- a/script/upstream-analyzer/cli-config.ts
+++ b/script/upstream-analyzer/cli-config.ts
@@ -1,14 +1,21 @@
 import { availableProviders, parseChainSpec, PROVIDERS, type ChainEntry } from "./providers"
 import type { AnalyzerConfig } from "./types"
 
+// Chain ordering: strongest free model first, unlimited-daily provider as
+// rate-limit fallback, quota-limited provider only as last resort.
+// OpenRouter free tier offers 1000 req/day with $10+ credits and carries
+// the best free models (nemotron-120b, qwen3-coder). NVIDIA NIM has a
+// 40-rpm limit but effectively unlimited daily capacity, so it absorbs
+// bursts after OpenRouter rate-limits. GitHub Models has tight daily caps
+// (150 rpd low-tier, 50 rpd high-tier) so it sits at the end as safety net.
 const DEFAULT_CLASSIFY_CHAIN =
-  "github:openai/gpt-4.1-mini,openrouter:qwen/qwen3-coder:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1"
+  "openrouter:qwen/qwen3-coder:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1-mini"
 
 const DEFAULT_SLOP_VERIFY_CHAIN =
-  "nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,openrouter:nvidia/nemotron-3-super-120b-a12b:free,github:openai/gpt-4.1"
+  "openrouter:nvidia/nemotron-3-super-120b-a12b:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
 
 const DEFAULT_SYNTHESIS_CHAIN =
-  "openrouter:qwen/qwen3-next-80b-a3b-instruct:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
+  "openrouter:nvidia/nemotron-3-super-120b-a12b:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1"
 
 function requireEnv(name: string): string {
   const value = process.env[name]

--- a/script/upstream-analyzer/cli-config.ts
+++ b/script/upstream-analyzer/cli-config.ts
@@ -1,13 +1,15 @@
 import { availableProviders, parseChainSpec, PROVIDERS, type ChainEntry } from "./providers"
 import type { AnalyzerConfig } from "./types"
 
-// Chain ordering: strongest free model first, unlimited-daily provider as
-// rate-limit fallback, quota-limited provider only as last resort.
-// OpenRouter free tier offers 1000 req/day with $10+ credits and carries
-// the best free models (nemotron-120b, qwen3-coder). NVIDIA NIM has a
-// 40-rpm limit but effectively unlimited daily capacity, so it absorbs
-// bursts after OpenRouter rate-limits. GitHub Models has tight daily caps
-// (150 rpd low-tier, 50 rpd high-tier) so it sits at the end as safety net.
+// Chain ordering: strongest free model first, unlimited-daily provider
+// next, quota-limited provider last. Fallback triggers on any retriable
+// failure (429 rate limit, 402 credit, 403 quota, 400 context) as defined
+// in ai-client classifyError(). Per-provider rate caps live in providers.ts
+// (PROVIDERS.<name>.rateLimitPerMinute) -- see that file for the source of
+// truth on throttling. The rationale for ordering is that OpenRouter free
+// hosts the strongest free models (nemotron-120b, qwen3-coder-480b) but
+// has a daily cap, NVIDIA NIM has generous rate-limited capacity with
+// no meaningful daily cap, and GitHub Models has the tightest daily caps.
 const DEFAULT_CLASSIFY_CHAIN =
   "openrouter:qwen/qwen3-coder:free,nvidia:nvidia/llama-3.3-nemotron-super-49b-v1,github:openai/gpt-4.1-mini"
 


### PR DESCRIPTION
## Summary

Reorder the default provider:model chains so the strongest free model runs first and we only degrade to quota-limited providers on rate-limit. Previously GitHub Models was the classify primary, which burned the 150 rpd cap fastest and left NVIDIA/OpenRouter quota unused.

## New ordering rationale

| Rank | Provider | Daily ceiling | Role |
|---|---|---|---|
| 1 | OpenRouter (\`:free\`) | 1000 rpd with $10+ credits | Primary: best free models live here |
| 2 | NVIDIA NIM | 40 rpm / ~57k rpd | Fallback: absorbs bursts when OpenRouter rate-limits |
| 3 | GitHub Models | 150 rpd low / 50 rpd high | Safety net |

## Per-pass chains

**Pass 1 (classify, 116 commits)**
1. \`openrouter:qwen/qwen3-coder:free\` — 480B MoE, 262K context, tools + JSON + structured
2. \`nvidia:nvidia/llama-3.3-nemotron-super-49b-v1\`
3. \`github:openai/gpt-4.1-mini\`

**Pass 2 (slop-verify, only on SLOP candidates)**
1. \`openrouter:nvidia/nemotron-3-super-120b-a12b:free\` — best free model overall
2. \`nvidia:nvidia/llama-3.3-nemotron-super-49b-v1\`
3. \`github:openai/gpt-4.1\`

**Pass 3 (synthesis, 1 call per release)**
1. \`openrouter:nvidia/nemotron-3-super-120b-a12b:free\` (promoted from qwen3-next-80b; nemotron-120b is stronger for cost-benefit reasoning)
2. \`nvidia:nvidia/llama-3.3-nemotron-super-49b-v1\`
3. \`github:openai/gpt-4.1\`

## Why this order?

- **OpenRouter free** is the only tier where the very strongest free models (nvidia/nemotron-120b, qwen/qwen3-coder-480b) live. Burn OpenRouter's 1000 rpd first to maximize quality.
- **NVIDIA NIM** has no meaningful daily cap (40 rpm ≈ 57k rpd) but slightly weaker models on the free hosted tier. Perfect for absorbing rate-limit bursts from OpenRouter.
- **GitHub Models** has the tightest daily caps. Reserve for true emergencies.

## Files changed

- \`script/upstream-analyzer/cli-config.ts\` — updated \`DEFAULT_*_CHAIN\` constants with rationale comment
- \`.github/workflows/upstream-analyzer.yml\` — updated both the \`workflow_dispatch\` input defaults and the shell fallback defaults

## Verification

- \`bun run typecheck\` — clean
- \`actionlint\` — clean

## Next step

After merge, run the analyzer against v3.17.0 → v3.17.4 and evaluate classification accuracy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered analyzer chains to run the strongest free models first via `openrouter`, then `nvidia`, with `github` last. Improves quality while conserving GitHub quotas; synthesis now aligns on `nemotron-120b` and comments document fallback rules.

- **Refactors**
  - New default order per pass: classify uses `openrouter:qwen/qwen3-coder:free` first; slop-verify and synthesis use `openrouter:nvidia/nemotron-3-super-120b-a12b:free` first; all then fall back to `nvidia:nvidia/llama-3.3-nemotron-super-49b-v1` and `github` models.
  - Synced defaults in `script/upstream-analyzer/cli-config.ts` and `.github/workflows/upstream-analyzer.yml` (inputs and shell fallbacks).
  - Clarified in-code rationale: point to `providers.ts` as the throttle source of truth and note retriable fallback errors (429/402/403/400 context).

<sup>Written for commit a6d55009a49e64374ba659f65a22afc8502af83a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

