### PR TITLE
fix(analyzer): retry OpenRouter provider-selection failures in fallback chain

### DIFF
--- a/script/upstream-analyzer/ai-client.ts
+++ b/script/upstream-analyzer/ai-client.ts
@@ -47,6 +47,10 @@ function stringifyBody(raw: unknown): string {
   }
 }
 
+function isProviderSelectionFailure(body: string): boolean {
+  return /no allowed providers are available for the selected model|no such provider/i.test(body)
+}
+
 function classifyError(err: unknown): ProviderFailureInfo {
   // APICallError.isInstance is the SDK-supported cross-realm check; plain
   // `instanceof` can miss errors constructed by a different copy of the
@@ -54,6 +58,9 @@ function classifyError(err: unknown): ProviderFailureInfo {
   if (APICallError.isInstance(err)) {
     const status = err.statusCode ?? 0
     const body = stringifyBody(err.responseBody ?? err.message)
+    if (isProviderSelectionFailure(body)) {
+      return { retriable: true, reason: `provider selection ${body.slice(0, 200)}` }
+    }
     if (status === 429) return { retriable: true, reason: `429 ${body.slice(0, 200)}` }
     if (status === 402) return { retriable: true, reason: `402 ${body.slice(0, 200)}` }
     if (status === 403 && /quota|rate|exceed/i.test(body)) {
@@ -64,7 +71,11 @@ function classifyError(err: unknown): ProviderFailureInfo {
     }
     return { retriable: false, reason: `${status} ${body.slice(0, 200)}` }
   }
-  return { retriable: false, reason: String(err) }
+  const message = String(err)
+  if (isProviderSelectionFailure(message)) {
+    return { retriable: true, reason: `provider selection ${message.slice(0, 200)}` }
+  }
+  return { retriable: false, reason: message }
 }
 
 async function callWithoutTools<TObject>(


### PR DESCRIPTION
## Summary

The latest analyzer run succeeded operationally but produced unusable classifications:

- 116 / 116 commits => `NEEDS_REVIEW`
- `confidence = low`
- `reason = "Classification failed: No allowed providers are available for the selected model."`

This was not a model-judgment failure. It was fallback logic stopping too early.

## Root cause

`classifyError()` only treated quota/context style failures as retriable:
- 429
- 402
- 403 with quota/rate text
- 400 with context text

OpenRouter's model-selection failure text:

`No allowed providers are available for the selected model.`

was treated as terminal, so the chain never reached NVIDIA NIM or GitHub Models.

## Fix

Add `isProviderSelectionFailure()` and classify these as retriable:
- `No allowed providers are available for the selected model`
- `No such provider`

Handle it in both paths:
1. `APICallError` branch (message can live in `responseBody`)
2. generic non-`APICallError` branch (message-only errors)

## Why this is the right behavior

Provider/model selection failures are local to the current chain entry. They do **not** mean the overall classification request is invalid. If OpenRouter rejects `qwen/qwen3-coder:free`, the correct behavior is:

`openrouter -> nvidia -> github`

not

`openrouter rejects -> mark commit NEEDS_REVIEW low confidence -> stop`

## Verification

- `bun run typecheck` clean
- zero API-surface change outside fallback classification

## Expected result after merge

Re-running `v3.17.0 -> v3.17.4` should produce real model output via NVIDIA fallback instead of 116 identical low-confidence fallback classifications.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry OpenRouter provider-selection failures in the analyzer so the fallback chain continues to other providers. This prevents mass low-confidence NEEDS_REVIEW results when OpenRouter rejects a model.

- **Bug Fixes**
  - Treat "No allowed providers are available for the selected model" and "No such provider" as retriable errors.
  - Handle in both error paths to allow fallback from `openrouter` to `nvidia` to `github`.

<sup>Written for commit b5467d08094a5b63351e5617b542bd1b153ba2b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

