### PR TITLE
docs: fork sync methodology + deviation register

### DIFF
--- a/docs/SYNC_METHODOLOGY.md
+++ b/docs/SYNC_METHODOLOGY.md
@@ -9,15 +9,29 @@ upstream, how fork-only fixes land, how we guard against AI slop, and when we
 publish npm releases. It describes what is already built and what the human
 maintainer still owns.
 
-## 0. DeepWiki is not an MCP
+## 0. Read the diff, not the title
 
-For the record: upstream PR #868 ("feat/deepwiki", merged as `987ae468`) added a
-single line to `README.md` — a [deepwiki.com](https://deepwiki.com) badge
-pointing to the auto-generated wiki for `code-yeongyu/oh-my-openagent`. That is
-the entire content of the PR. There is no DeepWiki MCP server, no tool
-registration, no plugin code. Any suggestion to "install DeepWiki MCP" in this
-fork is unverified and should be treated as speculation until independent
-evidence is produced.
+Commits and PRs mislead at a glance. A branch name like `feat/deepwiki`, a
+label like "integration", or a feature-sounding title suggests one scope; the
+actual diff may be something else entirely. Before classifying, porting,
+rejecting, or citing any upstream commit, read the file list and the line
+counts. Form the judgment from what the commit DOES, not what its title SAYS.
+
+Worked example. Upstream PR #868 ("feat/deepwiki", merged as `987ae468`)
+modifies exactly one file: `README.md`, one line added — a
+[deepwiki.com](https://deepwiki.com) badge pointing to the auto-generated wiki
+for `code-yeongyu/oh-my-openagent`. There is no source code, no MCP server, no
+tool registration, no plugin wiring. A title-only read invites the conclusion
+"DeepWiki integration is shipping in OmO, we should install a DeepWiki MCP in
+this fork." The diff does not support that conclusion. Any proposal leaning on
+PR #868 as evidence for a DeepWiki-shaped capability is unverified until the
+diff itself carries the weight.
+
+The rule generalizes. The analyzer's classifier (§6) scores each commit on
+what its diff contains, not on its title or commit message. Maintainers must
+apply the same discipline manually when reviewing the analyzer's draft PRs —
+especially for the `-good` batch, where a charitable title can smuggle in
+admin-only or churn-only commits that the file-list reveals immediately.
 
 ## 1. Ground truth snapshot
 

--- a/docs/SYNC_METHODOLOGY.md
+++ b/docs/SYNC_METHODOLOGY.md
@@ -1,0 +1,255 @@
+# Fork Sync & Upgrade Methodology
+
+**Package**: `@vacbo/oh-my-opencode`
+**Upstream**: `code-yeongyu/oh-my-openagent`
+**Last updated**: 2026-04-21
+
+This document is the canonical reference for how this fork stays synced with
+upstream, how fork-only fixes land, how we guard against AI slop, and when we
+publish npm releases. It describes what is already built and what the human
+maintainer still owns.
+
+## 0. DeepWiki is not an MCP
+
+For the record: upstream PR #868 ("feat/deepwiki", merged as `987ae468`) added a
+single line to `README.md` — a [deepwiki.com](https://deepwiki.com) badge
+pointing to the auto-generated wiki for `code-yeongyu/oh-my-openagent`. That is
+the entire content of the PR. There is no DeepWiki MCP server, no tool
+registration, no plugin code. Any suggestion to "install DeepWiki MCP" in this
+fork is unverified and should be treated as speculation until independent
+evidence is produced.
+
+## 1. Ground truth snapshot
+
+| Field | Value |
+| --- | --- |
+| Published version | `@vacbo/oh-my-opencode@3.18.0` |
+| Last upstream tag synced (`upstream-version.txt`) | `v3.17.0` |
+| Latest upstream stable tag | `v3.18.0` |
+| Fork `dev` vs `upstream/dev` | 43 ahead / 60 behind |
+| Sync pipeline | `upstream-tag-watcher.yml` + `upstream-analyzer.yml` (3-pass AI classifier) |
+| Release pipeline | `publish.yml` (main package + 11 platform binaries + GitHub release) |
+| Legacy pipeline | `sync-upstream.yml` — **disabled**, kept for reference |
+| Slop rubric | `.github/prompts/{commit-classify,slop-verify,release-synthesis}.md` |
+| Deviation register | `docs/fork-deviations.md` |
+
+## 2. Automated pipeline
+
+```
+upstream-tag-watcher.yml (cron */15)
+  │
+  │ new upstream v* tag?
+  ▼
+repository_dispatch: upstream-tag-detected
+  │
+  ▼
+upstream-analyzer.yml  (AI 3-pass)
+  │
+  │  Pass 1  classify each commit    GOOD / NEEDS_REVIEW / SLOP
+  │  Pass 2  verify SLOP candidates  (stronger model)
+  │  Pass 3  synthesize release      cost-benefit summary
+  │
+  │  Cherry-pick into   sync/upstream/{tag}-{good|review|slop}
+  │
+  ▼
+1 analysis issue + up to 3 draft PRs  (maintainer merges; no auto-merge)
+```
+
+Everything up to "draft PRs" runs without a human. Nothing is ever auto-merged
+or auto-published. The analyzer is advisory.
+
+Providers and chains are configured in `upstream-analyzer.yml` workflow inputs
+and `script/upstream-analyzer/providers.ts`. Default chain order is best-free
+first (OpenRouter → NVIDIA → GitHub Models).
+
+## 3. Manual gate — the six steps after the analyzer fires
+
+### Step A. Triage the analysis issue
+
+The analyzer opens a labeled issue with the release-level verdict. Read it
+before touching any PR. If the verdict is "mostly slop" across the window, you
+can legitimately skip this upstream release entirely — leave
+`upstream-version.txt` at its current value so the next analyzer run includes
+the skipped commits in a wider window.
+
+### Step B. Process the `-good` batch
+
+Default: merge after CI passes.
+
+Exception — **the classifier is known to be charitable** on administrative
+commits. Before merging, scan the batch for and drop:
+
+- CLA signature commits (`@X has signed the CLA in code-yeongyu/...`)
+- Release/version bump commits
+- Date-only or count-only doc churn
+- Minor visibility churn (`export` → internal with no caller benefit)
+
+Rebase or cherry-pick-minus to drop those, then merge.
+
+### Step C. Process the `-needs-review` batch
+
+Read each diff against the rubric in `.github/prompts/commit-classify.md`:
+
+- **Maze rule**: wrappers/adapters/hooks/indirection instead of a direct fix →
+  drop, unless the diff proves a real external constraint forced that design.
+- **AI-on-every-edit rule**: external model wired into routine edit actions by
+  default → drop, unless the diff proves a hard requirement.
+- Commits with measurable behavior delta and a real bug/feature → keep.
+
+### Step D. Process the `-slop` batch
+
+Default: close the draft PR, do not merge. These were flagged by two passes.
+If you override, document the reason in the close comment so the next reviewer
+sees the precedent.
+
+### Step E. Update `upstream-version.txt`
+
+After B-D conclude, bump `upstream-version.txt` to the tag you just processed.
+This is what the watcher reads to avoid re-firing on the same tag. Only bump
+after the work is actually merged.
+
+### Step F. Publish the fork release
+
+Dispatch `publish.yml` with `bump: patch` (or `minor` / `major` as appropriate).
+The workflow:
+
+1. Runs `bun test` + `bun run typecheck`
+2. Bumps version in root + all 11 platform `package.json` files
+3. Publishes `@vacbo/oh-my-opencode` with provenance
+4. Builds and publishes 11 platform binaries
+5. Tags `v{version}`, generates changelog, creates GitHub release
+6. Merges `dev` → `master`
+
+## 4. Fork-only fixes (changes that do not come from upstream)
+
+Path:
+
+1. Branch from `dev`: `feat/<scope>`, `fix/<scope>`, or `docs/<scope>`.
+2. PR to `dev` (not `master`). Reviewer applies the same slop rubric as upstream
+   commits — see §6.
+3. CI gates: `bun test`, `bun run typecheck`, publish workflow smoke tests.
+4. On merge, add a row to `docs/fork-deviations.md` with the SHA, category,
+   reason, and upstream plan (see §7).
+5. Next `publish.yml` dispatch folds the change into a release.
+
+Fork-only fixes must not land on `sync/upstream/*` branches — those are reserved
+for upstream cherry-picks so the analyzer's lineage tracking stays clean.
+
+## 5. Conflict resolution
+
+When a `sync/upstream/{tag}-{verdict}` cherry-pick conflicts:
+
+| Conflict type | Rule |
+| --- | --- |
+| Upstream changed a file we rewrote for slop | Prefer fork version. Re-classify upstream's change in next window. |
+| Upstream fixed a bug in code we no longer have | Drop the commit — not applicable. |
+| Upstream feature collides with a fork-only feature | Prefer fork version. Open an issue to either port the upstream approach or justify the permanent delta. |
+| Trivial formatting / line endings / timestamps | Take either side; auto-resolve if possible. |
+
+If resolving a single commit's conflict takes more than 10 minutes of manual
+work, stop and record it as a divergence-tax data point in a comment on the
+draft PR. Repeated high-tax conflicts are a signal that the relevant fork
+patches should be proposed upstream or reconsidered.
+
+## 6. Anti-slop checklist (apply to every PR — upstream-origin or fork-origin)
+
+Default to NEEDS_REVIEW when unsure. 60 seconds of human read is cheaper than a
+permanent slop merge.
+
+Reject any commit matching:
+
+- Abstraction with one caller and no clear growth path
+- Comments that restate the code
+- Commit message using "enhanced/improved/comprehensive/robust" without a
+  measurable metric or behavior delta
+- Docs that expand without new facts
+- Tautological tests (`expect(x).toBe(x)`)
+- Features gated behind flags with no consumer requesting them
+- Renamed symbols with no call-site benefit (pure churn)
+- Defensive `try/catch` around code that cannot throw
+- New dependency for trivial functionality
+- **Maze**: workaround via wrappers/adapters/hooks instead of a direct fix
+- Always-on hooks / wrappers / adapters with no root-cause justification
+- **AI-on-every-edit**: external model wired into routine edit actions by
+  default
+
+Category-first taxonomy (apply before the verdict):
+
+| Category | Examples | Default verdict |
+| --- | --- | --- |
+| Code-value | `real_bug_fix`, `real_test`, `real_feature`, `refactor_with_clear_value` | GOOD |
+| Suspicious | `refactor_churn`, `docs_churn`, `minor_visibility_churn`, `workflow_or_tooling_maze` | Lean SLOP |
+| Admin | `cla_admin`, `release_version_bump`, `governance_noise`, `date_count_metadata_churn` | Never GOOD |
+| Unclear | — | NEEDS_REVIEW |
+
+The canonical rubric lives in `.github/prompts/commit-classify.md`. This table
+is a human-facing summary; the prompt file is the source of truth.
+
+## 7. Deviation register
+
+`docs/fork-deviations.md` contains one row per fork-only commit with:
+
+- Commit SHA (short)
+- Category (analyzer-infra / scoped-package / sync-cherrypick / fork-only-fix /
+  ci-hardening / release-bot)
+- Reason the fork carries it
+- Upstream plan (never-upstream / try-to-upstream / already-from-upstream)
+
+Every new fork-only PR must add a row. Reviewer enforces. The register prevents
+drift-amnesia and gives future maintainers evidence when they ask "why do we
+have this?".
+
+## 8. Salvageable upstream PR backlog
+
+Upstream has PRs that were closed unmerged but look useful to us. Tracking them
+manually in `docs/salvageable-upstream-prs.md` (create on demand).
+Columns:
+
+- PR number and title
+- Upstream status (closed, stale, blocked)
+- Why it wasn't merged (if known)
+- Why this fork might want it
+- Decision: port now / port later / skip
+
+A future analyzer pass could classify closed-unmerged PRs automatically. That
+work is not yet scheduled.
+
+## 9. Release cadence
+
+| Trigger | Bump | Timing |
+| --- | --- | --- |
+| Upstream tag synced (merged `-good` + reviewed `-review`) | patch | 1-2 days after the tag |
+| Fork-only bug fix merged | patch | Batch with other recent work |
+| Fork-only feature merged | minor | When production-ready |
+| Breaking change | major | Deliberate; announce + migration guide |
+| Beta / RC | pre | Use `version` override with `-beta.N` / `-rc.N`; auto-publishes to `beta`/`rc` dist-tag |
+
+Do not release for every commit. The `publish.yml` run spans 11 platform
+binaries with provenance, costs CI time, and creates real npm state. Release
+when you have something a user would notice.
+
+## 10. What this document deliberately excludes
+
+- The analyzer's internal prompt engineering — owned by `.github/prompts/`.
+- The OmO source-code diagnostic plan (slop + performance audit of this fork
+  itself) — owned by `p10`, blocked on the diagnostic from `p9`.
+- The opencode-fork feasibility study — owned by `p11`.
+- Any changes to tool routing for subagents (WarpGrep, DeepWiki, GitHub MCP,
+  recursion depth) — separate research track, out of scope for sync methodology.
+
+## 11. Immediate backlog (as of 2026-04-21)
+
+Ordered by dependency.
+
+- [ ] Bump `upstream-version.txt` → `v3.17.4` to reflect what was actually
+      synced in the p9 window (per handoff plan §Context, lines 45-51).
+- [ ] Dispatch the analyzer for `v3.17.4 → v3.18.0` to catch up on the
+      60-commit gap on `upstream/dev`.
+- [ ] Review the 3 draft PRs it produces, applying §3 Steps B-D.
+- [ ] Bump `upstream-version.txt` → `v3.18.0` after the merge decisions
+      conclude.
+- [ ] Dispatch `publish.yml` with `bump: patch` → `@vacbo/oh-my-opencode@3.18.1`.
+- [ ] Optional: extend the analyzer with a pass over upstream's
+      closed-unmerged PRs (§8 future work).
+- [ ] Optional: turn the slop rubric inward onto this fork's own commits
+      (owned by `p10`).

--- a/docs/fork-deviations.md
+++ b/docs/fork-deviations.md
@@ -1,0 +1,133 @@
+# Fork Deviation Register
+
+**Purpose**: record every commit this fork carries that does not exist on
+`upstream/dev`. Prevents drift-amnesia. Gives future maintainers evidence when
+they ask "why do we have this?".
+
+**Scope**: commits on `dev` reachable from `HEAD` but not from `upstream/dev`.
+At snapshot time: 43 commits.
+
+**Snapshot**: `git log upstream/dev..dev` as of 2026-04-21, fork HEAD
+`5cd78886`, upstream HEAD `e0bcf3e2`, last sync target `v3.17.0` per
+`upstream-version.txt`.
+
+## Categories
+
+| Category | Meaning | Never-upstream? |
+| --- | --- | --- |
+| `analyzer-infra` | AI-powered upstream-release analyzer (tool, CI workflows, prompts) | Yes — fork-specific automation |
+| `scoped-package` | Switch from `oh-my-opencode` to `@vacbo/oh-my-opencode` scope, trusted publishing, ancillary test/doc fixes | Yes — fork identity |
+| `sync-cherrypick` | Cherry-picked from upstream in a prior sync window; stays on fork until formal tag sync | No — already upstream, just not yet rebased-over |
+| `fork-only-fix` | Bug fix or behavior change authored here that is not present upstream | Try-to-upstream or never-upstream, per-commit |
+| `ci-hardening` | Generic CI maintenance (action version bumps, retry logic) | Usually try-to-upstream |
+| `release-bot` | `release: vX.Y.Z` commits the `publish.yml` workflow writes | Never-upstream (per-fork release tracking) |
+
+## Summary
+
+| Category | Count |
+| --- | --- |
+| `analyzer-infra` | 14 |
+| `sync-cherrypick` | 11 |
+| `scoped-package` | 8 |
+| `fork-only-fix` | 5 |
+| `ci-hardening` | 3 |
+| `release-bot` | 2 |
+| **Total** | **43** |
+
+## Full register (43 commits)
+
+### analyzer-infra (14)
+
+| SHA | Date | Subject | Reason |
+| --- | --- | --- | --- |
+| `3ade0661` | 2026-04-17 | feat(ci): add AI-powered upstream release analyzer with draft PR batching (#1) | Anchor commit: 3-pass classify/verify/synthesize pipeline in `script/upstream-analyzer/` + `.github/prompts/` + `upstream-analyzer.yml`. |
+| `58a97e74` | 2026-04-17 | fix(ci): drop --frozen-lockfile from upstream-analyzer install (#2) | Align with repo-wide `bun install` convention. |
+| `21629d09` | 2026-04-17 | fix(analyzer): force-fetch upstream tags to tolerate fork history rewrites (#3) | Tolerate upstream's rewritten `v3.17.2`. |
+| `f95402c2` | 2026-04-17 | fix(analyzer): add rate limiting, working-tree reset, and partial persistence (#4) | Three run-2 bugs; persist classifications before pass 2 so crashes produce useful artifacts. |
+| `9c5361f5` | 2026-04-17 | fix(analyzer): workflow-permission push handling + gpt-5 max_completion_tokens (#5) | Handle `GITHUB_TOKEN` refusing workflow-file pushes; model-specific param selection. |
+| `43518042` | 2026-04-17 | fix(analyzer): write artifacts outside git worktree (use runner.temp) (#6) | Batch-build checkouts were erasing in-worktree `.analyzer-output/`. Centralize via `$GITHUB_ENV`. |
+| `859b3546` | 2026-04-17 | feat(analyzer): migrate to Vercel AI SDK with multi-provider harness + tools (#8) | Cross-provider fallback; tool-calling harness (`read_file`, `grep_callers`) with path sandboxing. |
+| `6599159d` | 2026-04-17 | feat(analyzer): lead chains with best free models, GitHub last (#9) | Default chain: OpenRouter → NVIDIA → GitHub Models. |
+| `b84199a5` | 2026-04-17 | fix(analyzer): retry provider-selection failures in fallback chain (#11) | Treat OpenRouter "No allowed providers" as retriable so the chain falls through. |
+| `a7078715` | 2026-04-17 | docs(analyzer): tighten slop rules for workaround-heavy AI hooks | AI-on-every-edit heuristic in `commit-classify.md`. |
+| `270dca80` | 2026-04-17 | docs(analyzer): add category-first taxonomy to prompts | Explicit `cla_admin` / `release_version_bump` / `date_count_metadata_churn` categories → never GOOD. |
+| `593bff78` | 2026-04-12 | ci(sync): add upstream auto-sync workflow | Legacy `sync-upstream.yml`; superseded by analyzer. Kept gated behind `yes-legacy-force-sync` input for reference. |
+| `399261b4` | 2026-04-15 | fix(ci): stop sync-upstream from auto-dispatching publish | Safety cutover when analyzer took over. |
+| `582ebc9a` | 2026-04-19 | fix(ci): grant contents:write so tag watcher can create repository_dispatch | `createDispatchEvent` needs `contents: write`, not `actions: write` alone. Watcher was 403'ing every 15 min. |
+
+### sync-cherrypick (11)
+
+| SHA | Date | Subject | Reason |
+| --- | --- | --- | --- |
+| `b9d5dd22` | 2026-04-14 | Merge commit '1bb59c3e' into dev | Upstream merge, part of p9 conservative sync. |
+| `cb15a7b6` | 2026-04-15 | chore(sync): merge upstream v3.17.3 | Upstream v3.17.3 merge; tracker not yet bumped to match. |
+| `67bc9613` | 2026-04-16 | feat(tool-metadata): add shared metadata contract and bridge | Upstream author YeonGyu-Kim; picked to unlock subsequent metadata fixes. |
+| `0eece31b` | 2026-04-16 | feat(background-agent): add wait-for-task-session helper | Upstream author YeonGyu-Kim. |
+| `4b8a23a2` | 2026-04-16 | fix(plugin): harden metadata recovery and extraction | Upstream author YeonGyu-Kim. |
+| `e7e67354` | 2026-04-18 | fix(plugin-handlers): hide demoted native plan agent | Real behavior fix from upstream (per p9 handoff §Context). |
+| `825da2f6` | 2026-04-18 | refactor(tools): migrate metadata producers to shared bridge | Ancillary to `67bc9613`. |
+| `a302d3cf` | 2026-04-18 | fix(shared): support anthropic OAuth auth detection | Real OAuth effort-clamping fix. |
+| `bb2d2b23` | 2026-04-18 | fix(cli): preserve hyphenated anthropic IDs in installer output | Installer output correctness. |
+| `87e084a6` | 2026-04-18 | fix(testing): avoid stale skill scans and preserve plugin alias | Root-cause fix for local test failures, not suppression. |
+| `3b745a04` | 2026-04-18 | fix(testing): widen plugin loader boundary test timeouts | Upstream test-stability fix. |
+
+### scoped-package (8)
+
+| SHA | Date | Subject | Reason |
+| --- | --- | --- | --- |
+| `da781c6b` | 2026-04-11 | build(publish): switch to @vacbo scope and trusted publishing | Anchor: fork identity. Never upstreamable. |
+| `84f41b79` | 2026-04-11 | build(schema): refresh config schema for skill source controls | Regen after scope-affecting schema updates. |
+| `5b978031` | 2026-04-11 | ci(publish): consolidate npm publishing into one workflow | Single `publish.yml` for scoped package flow. |
+| `7cfc679a` | 2026-04-12 | fix(ci): align tests with scoped package and Claude model IDs | Test updates for `@vacbo/...` imports + Claude ID format. |
+| `721a33a5` | 2026-04-12 | fix(ci): update cache sync tests for scoped package name | Scope-aware cache keys. |
+| `d30940da` | 2026-04-12 | fix(ci): update session and doctor tests for scoped package | Scope-aware test fixtures. |
+| `a8bc6122` | 2026-04-15 | docs(release): align scoped package install guidance | README install commands for `@vacbo/oh-my-opencode`. |
+| `42b87b31` | 2026-04-15 | fix(testing): stabilize release verification isolation | Release-verification tests isolation. |
+
+### fork-only-fix (5)
+
+| SHA | Date | Subject | Reason | Upstream plan |
+| --- | --- | --- | --- | --- |
+| `ceefa988` | 2026-04-11 | fix(skill-loader): continue nested discovery below parent skills | Skill loader wasn't recursing into child dirs; broke nested skill hierarchy. | Try-to-upstream |
+| `b45ded4f` | 2026-04-11 | fix(skill-context): add independent Claude and .agents skill gates | Separate gate flags per skill source so one source's skills don't leak. | Try-to-upstream |
+| `bea60840` | 2026-04-11 | fix(telemetry): require explicit opt-in and user-provided key | Telemetry off by default unless user actively opts in with their own key. | Fork-only (philosophy divergence) |
+| `b74a6215` | 2026-04-15 | fix(task-ui): normalize delegated task labels | Task UI was showing raw internal labels. | Try-to-upstream |
+| `d848d7f2` | 2026-04-15 | fix(command-config): honor separate claude skill sources | Companion to `b45ded4f` at command-config layer. | Try-to-upstream |
+
+Categorization note: `84f41b79` (schema regen) could plausibly live here as a
+fork-only-fix instead of under `scoped-package`. I placed it under
+`scoped-package` because the schema change is coupled to the scoped-package
+publishing artifact. Move it here if your mental model prefers the
+fork-only-fix framing; totals stay at 43 either way.
+
+### ci-hardening (3)
+
+| SHA | Date | Subject | Reason |
+| --- | --- | --- | --- |
+| `f9c5d411` | 2026-04-14 | fix(ci): retry publish when npm rejects immutable versions | npm version-collision retry loop; mirrored in `publish.yml`. |
+| `01404d28` | 2026-04-14 | fix(ci): upgrade checkout action to v5 | Node 20 → Node 24. |
+| `5cd78886` | 2026-04-19 | chore(ci): upgrade actions/github-script v7 -> v9 (node 24) | Kill the Node 20 deprecation warnings. |
+
+### release-bot (2)
+
+| SHA | Date | Subject | Reason |
+| --- | --- | --- | --- |
+| `e29972a6` | 2026-04-12 | release: v3.17.2 | Automated commit from `publish.yml`'s `release` job. |
+| `c9b352e1` | 2026-04-18 | release: v3.18.0 | Automated commit from `publish.yml`'s `release` job. |
+
+## Review notes
+
+- The `scoped-package` vs `fork-only-fix` boundary for `84f41b79` is judgment:
+  it's a schema regen whose trigger was skill-source-control work. Left under
+  `scoped-package` because the schema change is coupled to the packaged artifact.
+- Category totals above count each commit exactly once, by the most specific
+  category.
+- No commits currently classified as potentially-slop. If future reviewers find
+  one, move it here with justification and plan to revert.
+
+## Maintenance
+
+Every PR that lands a fork-only commit must update this file with a new row
+before merge. Reviewer enforces. The registry is refreshed (not rewritten) on
+each sync-and-release cycle: after `upstream-version.txt` bumps, the
+`sync-cherrypick` rows become upstream and can be collapsed.


### PR DESCRIPTION
## Summary

- Adds `docs/SYNC_METHODOLOGY.md` — canonical reference for how this fork stays synced with upstream, how fork-only fixes land, how the analyzer rubric prevents AI slop, and when to publish npm releases
- Adds `docs/fork-deviations.md` — categorized register of the 43 commits currently on `dev` that are not on `upstream/dev`
- Section 0 reframes around the "read the diff, not the title" principle

## Test Plan

Documentation only; no code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical docs for how `@vacbo/oh-my-opencode` stays in sync with `code-yeongyu/oh-my-openagent`, including review and release steps. Also adds a deviation register listing the 43 commits on `dev` that are not on `upstream/dev`.

- New Features
  - `docs/SYNC_METHODOLOGY.md`: end-to-end sync and release process, automated pipelines, six-step manual gate, conflict rules, and release cadence.
  - `docs/fork-deviations.md`: categorized register of 43 fork-only commits; reviewers must update it when landing fork-only changes.
  - Reframed Section 0 around “read the diff, not the title,” with a concise worked example.

<sup>Written for commit e7faf903bc5ac310c4d0e5e312a3693bf24fd588. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

