### PR TITLE
fix(config): accept any string in disabled_skills and disabled_commands

### DIFF
--- a/src/config/schema/agent-names.test.ts
+++ b/src/config/schema/agent-names.test.ts
@@ -20,4 +20,83 @@ describe("OhMyOpenCodeConfigSchema disabled_skills", () => {
       ])
     }
   })
+
+  test("accepts user-installed skill names (not just builtins)", () => {
+    // given
+    const config = {
+      disabled_skills: [
+        "qs-anti-patterns",
+        "my-custom-skill",
+        "frontend/nextjs",
+      ],
+    }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.disabled_skills).toEqual([
+        "qs-anti-patterns",
+        "my-custom-skill",
+        "frontend/nextjs",
+      ])
+    }
+  })
+
+  test("rejects empty strings", () => {
+    // given
+    const config = { disabled_skills: [""] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("OhMyOpenCodeConfigSchema disabled_commands", () => {
+  test("accepts builtin command names", () => {
+    // given
+    const config = { disabled_commands: ["init-deep", "refactor"] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.disabled_commands).toEqual(["init-deep", "refactor"])
+    }
+  })
+
+  test("accepts user-defined command names (not just builtins)", () => {
+    // given
+    const config = { disabled_commands: ["my-custom-command", "review-pr"] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.disabled_commands).toEqual([
+        "my-custom-command",
+        "review-pr",
+      ])
+    }
+  })
+
+  test("rejects empty strings", () => {
+    // given
+    const config = { disabled_commands: [""] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
 })

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -1,6 +1,5 @@
 import { z } from "zod"
 import { AnyMcpNameSchema } from "../../mcp/types"
-import { BuiltinSkillNameSchema } from "./agent-names"
 import { AgentDefinitionsConfigSchema } from "./agent-definitions"
 import { AgentOverridesSchema } from "./agent-overrides"
 import { BabysittingConfigSchema } from "./babysitting"
@@ -9,7 +8,6 @@ import { BrowserAutomationConfigSchema } from "./browser-automation"
 import { CategoriesConfigSchema } from "./categories"
 import { ClaudeCodeConfigSchema } from "./claude-code"
 import { CommentCheckerConfigSchema } from "./comment-checker"
-import { BuiltinCommandNameSchema } from "./commands"
 import { ExperimentalConfigSchema } from "./experimental"
 import { GitMasterConfigSchema } from "./git-master"
 import { NotificationConfigSchema } from "./notification"
@@ -34,9 +32,19 @@ export const OhMyOpenCodeConfigSchema = z.object({
   agent_definitions: AgentDefinitionsConfigSchema,
   disabled_mcps: z.array(AnyMcpNameSchema).optional(),
   disabled_agents: z.array(z.string()).optional(),
-  disabled_skills: z.array(BuiltinSkillNameSchema).optional(),
+  /**
+   * Skills to hide from discovery. Accepts any skill name — not just builtins.
+   * Matches against the skill's registered name (e.g. "review-work",
+   * "qs-anti-patterns", or user-installed skill names). Unknown names are a
+   * silent no-op so stale entries don't break config parsing.
+   */
+  disabled_skills: z.array(z.string().min(1)).optional(),
   disabled_hooks: z.array(z.string()).optional(),
-  disabled_commands: z.array(BuiltinCommandNameSchema).optional(),
+  /**
+   * Commands to hide. Accepts any command name — not just builtins. Unknown
+   * names are a silent no-op.
+   */
+  disabled_commands: z.array(z.string().min(1)).optional(),
   /** Disable specific tools by name (e.g., ["todowrite", "todoread"]) */
   disabled_tools: z.array(z.string()).optional(),
   mcp_env_allowlist: z.array(z.string()).optional(),

--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -125,7 +125,7 @@ $ARGUMENTS
 }
 
 export function loadBuiltinCommands(
-  disabledCommands?: BuiltinCommandName[],
+  disabledCommands?: readonly string[],
   options?: LoadBuiltinCommandsOptions,
 ): BuiltinCommands {
   const builtinCommandDefinitions = createBuiltinCommandDefinitions(options)
@@ -133,7 +133,7 @@ export function loadBuiltinCommands(
   const commands: BuiltinCommands = {}
 
   for (const [name, definition] of Object.entries(builtinCommandDefinitions)) {
-    if (!disabled.has(name as BuiltinCommandName)) {
+    if (!disabled.has(name)) {
       const { argumentHint: _argumentHint, ...openCodeCompatible } = definition
       commands[name] = { ...openCodeCompatible, name } as CommandDefinition
     }


### PR DESCRIPTION
## Summary

- Before: `disabled_skills` required one of 7 hardcoded builtin names; `disabled_commands` required one of 9 hardcoded builtin names. Users with many user-installed skills could not disable any of them because the Zod schema rejected unknown names at parse time.
- After: both fields accept any non-empty string. Unknown names are silent no-ops at the loader layer, which already handles arbitrary skill/command names via Set lookups.
- The type widening is strictly permissive: every value that parsed before still parses after.

## Test Plan

- `bun test src/config/schema/agent-names.test.ts` — 6 tests pass (2 pre-existing + 4 new)
- `bun run typecheck` — clean
- Full suite: 5612/5612 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow disabling any skill or command by name in config, not just built-ins. Unknown names are ignored at load time, and existing configs continue to work.

- **Bug Fixes**
  - Widened Zod schema: `disabled_skills` and `disabled_commands` now accept `z.array(z.string().min(1))`.
  - Updated `loadBuiltinCommands` to accept `readonly string[]`; added tests for user-installed names and empty-string rejection.

<sup>Written for commit 157b780079aeb593a2270c80ce97a13cbd8101c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

