### PR TITLE
feat(skill-loader): honor user-invocable spec field + OmO hide_nested_by_default flag

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,6 +14,7 @@ export type {
   ExperimentalConfig,
   DynamicContextPruningConfig,
   RalphLoopConfig,
+  SkillsConfig,
   TmuxConfig,
   TmuxLayout,
   SisyphusConfig,

--- a/src/config/schema/skills.ts
+++ b/src/config/schema/skills.ts
@@ -32,6 +32,23 @@ export const SkillsConfigSchema = z.union([
     sources: z.array(SkillSourceSchema).optional(),
     enable: z.array(z.string()).optional(),
     disable: z.array(z.string()).optional(),
+    /**
+     * Inverts the Claude Code spec default (user-invocable: true) for
+     * NESTED skills only. When true, a nested skill is hidden from the
+     * slash-command picker unless its SKILL.md frontmatter explicitly
+     * sets `user-invocable: true`. Top-level skills are unaffected.
+     *
+     * Rationale: large skill hubs (quality-standard, reverse-engineering,
+     * etc.) ship many child skills that authors intended as supporting
+     * routines, not standalone slash commands. Flipping this flag once
+     * replaces per-SKILL.md opt-out work with per-SKILL.md opt-in for
+     * the few children you actually want in the picker.
+     *
+     * Nested skills remain fully callable by agents via the skill tool,
+     * the UI Skills picker, and load_skills delegation regardless of
+     * this flag.
+     */
+    hide_nested_by_default: z.boolean().optional(),
   }).catchall(SkillEntrySchema),
 ])
 

--- a/src/features/opencode-skill-loader/async-loader.test.ts
+++ b/src/features/opencode-skill-loader/async-loader.test.ts
@@ -88,8 +88,11 @@ Skill body.
       expect(skills[0].name).toBe("named-skill")
     })
 
-    it("discovers direct .md files", async () => {
-      // given
+    it("ignores direct .md files at the skills root (not a SKILL.md entrypoint)", async () => {
+      // given — plain markdown file directly under the skills root.
+      // Per the Anthropic Agent Skills spec, a skill is a directory
+      // containing SKILL.md. A bare .md file is supporting material,
+      // not a skill, so discovery must skip it.
       const skillContent = `---
 name: direct-skill
 description: Direct markdown file
@@ -103,8 +106,7 @@ Direct skill.
       const skills = await discoverSkillsInDirAsync(SKILLS_DIR)
 
       // then
-      expect(skills).toHaveLength(1)
-      expect(skills[0].name).toBe("direct-skill")
+      expect(skills).toHaveLength(0)
     })
 
     it("preserves nested skill path names during recursive discovery", async () => {
@@ -155,8 +157,11 @@ Nested skill.
       expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
     })
 
-    it("preserves nested skill path names for nested direct markdown discovery", async () => {
-      // given
+    it("ignores sibling .md files inside a nested directory that lacks SKILL.md or {dirName}.md", async () => {
+      // given — a nested directory holding only a plain .md file with
+      // neither a SKILL.md entrypoint nor a {dirName}.md fallback.
+      // Discovery must recurse but find no invocable skill, since
+      // supporting .md files are not skills per spec.
       const nestedSkillDir = join(SKILLS_DIR, "superpowers")
       mkdirSync(nestedSkillDir, { recursive: true })
       writeFileSync(
@@ -174,9 +179,7 @@ Nested skill.
       const skills = await discoverSkillsInDirAsync(SKILLS_DIR)
 
       // then
-      expect(skills).toHaveLength(1)
-      expect(skills[0]?.name).toBe("superpowers/brainstorming")
-      expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
+      expect(skills).toHaveLength(0)
     })
 
     it("skips entries starting with dot", async () => {

--- a/src/features/opencode-skill-loader/async-loader.ts
+++ b/src/features/opencode-skill-loader/async-loader.ts
@@ -163,46 +163,58 @@ export async function discoverSkillsInDirAsync(
     const processEntry = async (entry: Dirent): Promise<LoadedSkill | LoadedSkill[] | null> => {
       if (entry.name.startsWith(".")) return null
 
+      if (!(entry.isDirectory() || entry.isSymbolicLink())) {
+        return null
+      }
+
       const entryPath = join(skillsDir, entry.name)
+      const resolvedPath = resolveSymlink(entryPath)
+      const dirName = entry.name
 
-      if (entry.isDirectory() || entry.isSymbolicLink()) {
-        const resolvedPath = resolveSymlink(entryPath)
-        const dirName = entry.name
-
-        const skillMdPath = join(resolvedPath, "SKILL.md")
-        try {
-          await readFile(skillMdPath, "utf-8")
-          return await loadSkillFromPathAsync(skillMdPath, resolvedPath, dirName, scope, namePrefix)
-        } catch {
-          const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
-          try {
-            await readFile(namedSkillMdPath, "utf-8")
-            return await loadSkillFromPathAsync(namedSkillMdPath, resolvedPath, dirName, scope, namePrefix)
-          } catch {
-            if (depth >= maxDepth) {
-              return null
-            }
-
-            const nestedPrefix = namePrefix ? `${namePrefix}/${dirName}` : dirName
-            const nestedSkills = await discoverSkillsInDirAsync(
-              resolvedPath,
-              scope,
-              nestedPrefix,
-              depth + 1,
-              maxDepth
-            )
-
-            return nestedSkills.length > 0 ? nestedSkills : null
-          }
-        }
+      const skillMdPath = join(resolvedPath, "SKILL.md")
+      try {
+        await readFile(skillMdPath, "utf-8")
+        return await loadSkillFromPathAsync(
+          skillMdPath,
+          resolvedPath,
+          dirName,
+          scope,
+          namePrefix,
+          depth,
+        )
+      } catch {
+        // fall through to {dirName}.md fallback and recursive descent
       }
 
-      if (isMarkdownFile(entry)) {
-        const skillName = basename(entry.name, ".md")
-        return await loadSkillFromPathAsync(entryPath, skillsDir, skillName, scope, namePrefix)
+      const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
+      try {
+        await readFile(namedSkillMdPath, "utf-8")
+        return await loadSkillFromPathAsync(
+          namedSkillMdPath,
+          resolvedPath,
+          dirName,
+          scope,
+          namePrefix,
+          depth,
+        )
+      } catch {
+        // no entrypoint in this directory; recurse if depth allows
       }
 
-      return null
+      if (depth >= maxDepth) {
+        return null
+      }
+
+      const nestedPrefix = namePrefix ? `${namePrefix}/${dirName}` : dirName
+      const nestedSkills = await discoverSkillsInDirAsync(
+        resolvedPath,
+        scope,
+        nestedPrefix,
+        depth + 1,
+        maxDepth,
+      )
+
+      return nestedSkills.length > 0 ? nestedSkills : null
     }
 
     const skillPromises = await mapWithConcurrency(entries, processEntry, 16)

--- a/src/features/opencode-skill-loader/async-loader.ts
+++ b/src/features/opencode-skill-loader/async-loader.ts
@@ -76,13 +76,14 @@ export async function loadSkillFromPathAsync(
   resolvedPath: string,
   defaultName: string,
   scope: SkillScope,
-  namePrefix = ""
+  namePrefix = "",
+  depth = 0,
 ): Promise<LoadedSkill | null> {
   try {
     const content = await readFile(skillPath, "utf-8")
     const { data, body, parseError } = parseFrontmatter<SkillMetadata>(content)
     if (parseError) return null
-    
+
     const frontmatterMcp = parseSkillMcpConfigFromFrontmatter(content)
     const mcpJsonMcp = await loadMcpJsonFromDirAsync(resolvedPath)
     const mcpConfig = mcpJsonMcp || frontmatterMcp
@@ -115,6 +116,8 @@ $ARGUMENTS
       argumentHint: data["argument-hint"],
     }
 
+    const isNested = depth > 0
+
     return {
       name: skillName,
       path: skillPath,
@@ -126,6 +129,9 @@ $ARGUMENTS
       metadata: data.metadata,
       allowedTools: parseAllowedTools(data["allowed-tools"]),
       mcpConfig,
+      depth,
+      userInvocable: data["user-invocable"],
+      flatName: isNested ? baseName : undefined,
     }
   } catch {
     return null

--- a/src/features/opencode-skill-loader/blocking.test.ts
+++ b/src/features/opencode-skill-loader/blocking.test.ts
@@ -17,13 +17,13 @@ afterEach(() => {
 
 describe("discoverAllSkillsBlocking", () => {
   it("returns skills synchronously from valid directories", () => {
-    // given valid skill directory
-    const skillDir = join(TEST_DIR, "skills")
+    // given a skill directory with a proper SKILL.md entrypoint
+    const skillsRoot = join(TEST_DIR, "skills")
+    const skillDir = join(skillsRoot, "test-skill")
     mkdirSync(skillDir, { recursive: true })
 
-    const skillMdPath = join(skillDir, "test-skill.md")
     writeFileSync(
-      skillMdPath,
+      join(skillDir, "SKILL.md"),
       `---
 name: test-skill
 description: A test skill
@@ -31,7 +31,7 @@ description: A test skill
 This is test skill content.`
     )
 
-    const dirs = [skillDir]
+    const dirs = [skillsRoot]
     const scopes: SkillScope[] = ["opencode-project"]
 
     // when discoverAllSkillsBlocking called
@@ -76,14 +76,14 @@ This is test skill content.`
   })
 
   it("handles multiple directories with mixed content", () => {
-    // given multiple directories with valid and invalid skills
+    // given two skills roots, each containing one directory skill with SKILL.md
     const dir1 = join(TEST_DIR, "dir1")
     const dir2 = join(TEST_DIR, "dir2")
-    mkdirSync(dir1, { recursive: true })
-    mkdirSync(dir2, { recursive: true })
+    mkdirSync(join(dir1, "skill1"), { recursive: true })
+    mkdirSync(join(dir2, "skill2"), { recursive: true })
 
     writeFileSync(
-      join(dir1, "skill1.md"),
+      join(dir1, "skill1", "SKILL.md"),
       `---
 name: skill1
 description: First skill
@@ -92,7 +92,7 @@ Skill 1 content.`
     )
 
     writeFileSync(
-      join(dir2, "skill2.md"),
+      join(dir2, "skill2", "SKILL.md"),
       `---
 name: skill2
 description: Second skill
@@ -109,19 +109,19 @@ Skill 2 content.`
     // then returns all valid skills
     expect(skills).toBeArray()
     expect(skills.length).toBe(2)
-    
+
     const skillNames = skills.map(s => s.name).sort()
     expect(skillNames).toEqual(["skill1", "skill2"])
   })
 
   it("skips invalid YAML files", () => {
-    // given directory with invalid YAML
-    const skillDir = join(TEST_DIR, "skills")
-    mkdirSync(skillDir, { recursive: true })
+    // given a skills root with one valid and one invalid SKILL.md directory
+    const skillsRoot = join(TEST_DIR, "skills")
+    mkdirSync(join(skillsRoot, "valid-skill"), { recursive: true })
+    mkdirSync(join(skillsRoot, "invalid-skill"), { recursive: true })
 
-    const validSkillPath = join(skillDir, "valid.md")
     writeFileSync(
-      validSkillPath,
+      join(skillsRoot, "valid-skill", "SKILL.md"),
       `---
 name: valid-skill
 description: Valid skill
@@ -129,9 +129,8 @@ description: Valid skill
 Valid skill content.`
     )
 
-    const invalidSkillPath = join(skillDir, "invalid.md")
     writeFileSync(
-      invalidSkillPath,
+      join(skillsRoot, "invalid-skill", "SKILL.md"),
       `---
 name: invalid skill
 description: [ invalid yaml
@@ -139,7 +138,7 @@ description: [ invalid yaml
 Invalid content.`
     )
 
-    const dirs = [skillDir]
+    const dirs = [skillsRoot]
     const scopes: SkillScope[] = ["opencode-project"]
 
     // when discoverAllSkillsBlocking called
@@ -180,15 +179,15 @@ This is a directory-based skill.`
   })
 
   it("processes large skill sets without timeout", () => {
-    // given directory with many skills (20+)
-    const skillDir = join(TEST_DIR, "many-skills")
-    mkdirSync(skillDir, { recursive: true })
+    // given a skills root with many directory-based skills (20+)
+    const skillsRoot = join(TEST_DIR, "many-skills")
 
     const skillCount = 25
     for (let i = 0; i < skillCount; i++) {
-      const skillPath = join(skillDir, `skill-${i}.md`)
+      const skillDir = join(skillsRoot, `skill-${i}`)
+      mkdirSync(skillDir, { recursive: true })
       writeFileSync(
-        skillPath,
+        join(skillDir, "SKILL.md"),
         `---
 name: skill-${i}
 description: Skill number ${i}
@@ -197,7 +196,7 @@ Content for skill ${i}.`
       )
     }
 
-    const dirs = [skillDir]
+    const dirs = [skillsRoot]
     const scopes: SkillScope[] = ["opencode-project"]
 
     // when discoverAllSkillsBlocking called

--- a/src/features/opencode-skill-loader/loaded-skill-from-path.ts
+++ b/src/features/opencode-skill-loader/loaded-skill-from-path.ts
@@ -14,8 +14,11 @@ export async function loadSkillFromPath(options: {
   defaultName: string
   scope: SkillScope
   namePrefix?: string
+  depth?: number
 }): Promise<LoadedSkill | null> {
   const namePrefix = options.namePrefix ?? ""
+  const depth = options.depth ?? 0
+  const isNested = depth > 0
 
   try {
     const content = await fs.readFile(options.skillPath, "utf-8")
@@ -62,6 +65,9 @@ export async function loadSkillFromPath(options: {
       allowedTools: parseAllowedTools(data["allowed-tools"]),
       mcpConfig,
       lazyContent: eagerLoader,
+      depth,
+      userInvocable: data["user-invocable"],
+      flatName: isNested ? baseName : undefined,
     }
   } catch {
     return null

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -10,33 +10,48 @@ import {
 } from "../../shared/project-discovery-dirs"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { LoadedSkill } from "./types"
-import { skillsToCommandDefinitionRecord } from "./skill-definition-record"
+import {
+  skillsToCommandDefinitionRecord,
+  type SkillsToCommandDefinitionRecordOptions,
+} from "./skill-definition-record"
 import { deduplicateSkillsByName } from "./skill-deduplication"
 import { loadSkillsFromDir } from "./skill-directory-loader"
 
-export async function loadUserSkills(): Promise<Record<string, CommandDefinition>> {
+export type LoadSkillsAsCommandsOptions = SkillsToCommandDefinitionRecordOptions
+
+export async function loadUserSkills(
+  options: LoadSkillsAsCommandsOptions = {},
+): Promise<Record<string, CommandDefinition>> {
   const userSkillsDir = join(getClaudeConfigDir(), "skills")
   const skills = await loadSkillsFromDir({ skillsDir: userSkillsDir, scope: "user" })
-  return skillsToCommandDefinitionRecord(skills)
+  return skillsToCommandDefinitionRecord(skills, options)
 }
 
-export async function loadProjectSkills(directory?: string): Promise<Record<string, CommandDefinition>> {
+export async function loadProjectSkills(
+  directory?: string,
+  options: LoadSkillsAsCommandsOptions = {},
+): Promise<Record<string, CommandDefinition>> {
   const projectSkillDirs = findProjectClaudeSkillDirs(directory ?? process.cwd())
   const allSkills = await Promise.all(
     projectSkillDirs.map((skillsDir) => loadSkillsFromDir({ skillsDir, scope: "project" })),
   )
-  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()))
+  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()), options)
 }
 
-export async function loadOpencodeGlobalSkills(): Promise<Record<string, CommandDefinition>> {
+export async function loadOpencodeGlobalSkills(
+  options: LoadSkillsAsCommandsOptions = {},
+): Promise<Record<string, CommandDefinition>> {
   const skillDirs = getOpenCodeSkillDirs({ binary: "opencode" })
   const allSkills = await Promise.all(
     skillDirs.map(skillsDir => loadSkillsFromDir({ skillsDir, scope: "opencode" }))
   )
-  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()))
+  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()), options)
 }
 
-export async function loadOpencodeProjectSkills(directory?: string): Promise<Record<string, CommandDefinition>> {
+export async function loadOpencodeProjectSkills(
+  directory?: string,
+  options: LoadSkillsAsCommandsOptions = {},
+): Promise<Record<string, CommandDefinition>> {
   const opencodeProjectSkillDirs = findProjectOpencodeSkillDirs(
     directory ?? process.cwd(),
   )
@@ -45,21 +60,26 @@ export async function loadOpencodeProjectSkills(directory?: string): Promise<Rec
       loadSkillsFromDir({ skillsDir, scope: "opencode-project" }),
     ),
   )
-  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()))
+  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()), options)
 }
 
-export async function loadProjectAgentsSkills(directory?: string): Promise<Record<string, CommandDefinition>> {
+export async function loadProjectAgentsSkills(
+  directory?: string,
+  options: LoadSkillsAsCommandsOptions = {},
+): Promise<Record<string, CommandDefinition>> {
   const agentsProjectSkillDirs = findProjectAgentsSkillDirs(directory ?? process.cwd())
   const allSkills = await Promise.all(
     agentsProjectSkillDirs.map((skillsDir) => loadSkillsFromDir({ skillsDir, scope: "project" })),
   )
-  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()))
+  return skillsToCommandDefinitionRecord(deduplicateSkillsByName(allSkills.flat()), options)
 }
 
-export async function loadGlobalAgentsSkills(): Promise<Record<string, CommandDefinition>> {
+export async function loadGlobalAgentsSkills(
+  options: LoadSkillsAsCommandsOptions = {},
+): Promise<Record<string, CommandDefinition>> {
   const agentsGlobalDir = join(homedir(), ".agents", "skills")
   const skills = await loadSkillsFromDir({ skillsDir: agentsGlobalDir, scope: "user" })
-  return skillsToCommandDefinitionRecord(skills)
+  return skillsToCommandDefinitionRecord(skills, options)
 }
 
 export interface DiscoverSkillsOptions {

--- a/src/features/opencode-skill-loader/skill-definition-record.test.ts
+++ b/src/features/opencode-skill-loader/skill-definition-record.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "bun:test"
+import type { LoadedSkill } from "./types"
+import { skillsToCommandDefinitionRecord } from "./skill-definition-record"
+
+function makeSkill(partial: Partial<LoadedSkill> & { name: string }): LoadedSkill {
+  return {
+    scope: "user",
+    definition: {
+      name: partial.name,
+      description: `desc ${partial.name}`,
+      template: `template ${partial.name}`,
+    },
+    ...partial,
+  }
+}
+
+describe("skillsToCommandDefinitionRecord — spec-default (hideNestedByDefault: false)", () => {
+  it("includes top-level skills by default", () => {
+    // given
+    const skills: LoadedSkill[] = [
+      makeSkill({ name: "frontend" }),
+      makeSkill({ name: "backend" }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills)
+
+    // then
+    expect(Object.keys(record).sort()).toEqual(["backend", "frontend"])
+  })
+
+  it("includes nested skills under flat name when user-invocable is unset (spec default true)", () => {
+    // given
+    const skills: LoadedSkill[] = [
+      makeSkill({ name: "top-level", depth: 0 }),
+      makeSkill({ name: "parent/child", depth: 1, flatName: "child" }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills)
+
+    // then
+    expect(Object.keys(record).sort()).toEqual(["child", "top-level"])
+  })
+
+  it("hides any skill (top-level or nested) with user-invocable: false", () => {
+    // given
+    const skills: LoadedSkill[] = [
+      makeSkill({ name: "visible" }),
+      makeSkill({ name: "hidden-top", userInvocable: false }),
+      makeSkill({
+        name: "parent/hidden-child",
+        depth: 1,
+        flatName: "hidden-child",
+        userInvocable: false,
+      }),
+      makeSkill({
+        name: "parent/visible-child",
+        depth: 1,
+        flatName: "visible-child",
+      }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills)
+
+    // then
+    expect(Object.keys(record).sort()).toEqual(["visible", "visible-child"])
+  })
+})
+
+describe("skillsToCommandDefinitionRecord — OmO inversion (hideNestedByDefault: true)", () => {
+  it("hides nested skills whose user-invocable is unset", () => {
+    // given
+    const skills: LoadedSkill[] = [
+      makeSkill({ name: "top-level" }),
+      makeSkill({ name: "parent/child", depth: 1, flatName: "child" }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills, {
+      hideNestedByDefault: true,
+    })
+
+    // then — nested is hidden, top-level unaffected
+    expect(Object.keys(record).sort()).toEqual(["top-level"])
+  })
+
+  it("still shows nested skills that opt in with user-invocable: true", () => {
+    // given
+    const skills: LoadedSkill[] = [
+      makeSkill({ name: "top-level" }),
+      makeSkill({
+        name: "parent/opted-in",
+        depth: 1,
+        flatName: "opted-in",
+        userInvocable: true,
+      }),
+      makeSkill({
+        name: "parent/hidden-by-default",
+        depth: 1,
+        flatName: "hidden-by-default",
+      }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills, {
+      hideNestedByDefault: true,
+    })
+
+    // then — opted-in nested visible under flat name; other hidden
+    expect(Object.keys(record).sort()).toEqual(["opted-in", "top-level"])
+  })
+
+  it("leaves top-level skills unaffected regardless of the flag", () => {
+    // given
+    const skills: LoadedSkill[] = [
+      makeSkill({ name: "top-a" }),
+      makeSkill({ name: "top-b" }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills, {
+      hideNestedByDefault: true,
+    })
+
+    // then
+    expect(Object.keys(record).sort()).toEqual(["top-a", "top-b"])
+  })
+})
+
+describe("skillsToCommandDefinitionRecord — collision handling", () => {
+  it("falls back to prefixed path when two nested skills collide on flat name", () => {
+    // given
+    const skills: LoadedSkill[] = [
+      makeSkill({
+        name: "security/auth-patterns",
+        depth: 1,
+        flatName: "auth-patterns",
+      }),
+      makeSkill({
+        name: "quality-standard/auth-patterns",
+        depth: 1,
+        flatName: "auth-patterns",
+      }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills)
+
+    // then — first wins the flat key, second falls back to prefixed
+    expect(Object.keys(record).sort()).toEqual([
+      "auth-patterns",
+      "quality-standard/auth-patterns",
+    ])
+  })
+
+  it("yields to a top-level skill that owns the same flat name regardless of iteration order", () => {
+    // given — nested appears before top-level in input array
+    const skills: LoadedSkill[] = [
+      makeSkill({
+        name: "security/auth-patterns",
+        depth: 1,
+        flatName: "auth-patterns",
+      }),
+      makeSkill({ name: "auth-patterns" }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills)
+
+    // then — top-level owns flat slot, nested takes prefixed path
+    expect(Object.keys(record).sort()).toEqual([
+      "auth-patterns",
+      "security/auth-patterns",
+    ])
+  })
+})

--- a/src/features/opencode-skill-loader/skill-definition-record.ts
+++ b/src/features/opencode-skill-loader/skill-definition-record.ts
@@ -1,11 +1,94 @@
 import type { CommandDefinition } from "../claude-code-command-loader/types"
+import { log } from "../../shared/logger"
 import type { LoadedSkill } from "./types"
 
-export function skillsToCommandDefinitionRecord(skills: LoadedSkill[]): Record<string, CommandDefinition> {
+export interface SkillsToCommandDefinitionRecordOptions {
+  /**
+   * OmO-level override. When true, nested skills that do NOT set an
+   * explicit user-invocable value in frontmatter are hidden from the
+   * slash-command picker (inverts the Claude Code spec default of
+   * user-invocable: true for the nested case only). Frontmatter with
+   * an explicit true or false always wins. Top-level skills are never
+   * affected by this option.
+   */
+  hideNestedByDefault?: boolean
+}
+
+export function skillsToCommandDefinitionRecord(
+  skills: LoadedSkill[],
+  options: SkillsToCommandDefinitionRecordOptions = {},
+): Record<string, CommandDefinition> {
+  const hideNestedByDefault = options.hideNestedByDefault ?? false
   const result: Record<string, CommandDefinition> = {}
+  const keyAssignedTo = new Map<string, string>()
+
+  const topLevel: LoadedSkill[] = []
+  const nested: LoadedSkill[] = []
   for (const skill of skills) {
-    const { name: _name, argumentHint: _argumentHint, ...openCodeCompatible } = skill.definition
-    result[skill.name] = openCodeCompatible as CommandDefinition
+    if ((skill.depth ?? 0) > 0) {
+      nested.push(skill)
+    } else {
+      topLevel.push(skill)
+    }
   }
+
+  for (const skill of topLevel) {
+    if (!isVisibleInSlash(skill, false)) continue
+    registerSkill(result, keyAssignedTo, skill.name, skill)
+  }
+
+  for (const skill of nested) {
+    if (!isVisibleInSlash(skill, hideNestedByDefault)) continue
+    const slashKey = resolveNestedSlashKey(skill, keyAssignedTo)
+    registerSkill(result, keyAssignedTo, slashKey, skill)
+  }
+
   return result
+}
+
+function isVisibleInSlash(
+  skill: LoadedSkill,
+  hideNestedByDefault: boolean,
+): boolean {
+  if (skill.userInvocable === false) return false
+  if (skill.userInvocable === true) return true
+  const isNested = (skill.depth ?? 0) > 0
+  return !(isNested && hideNestedByDefault)
+}
+
+function registerSkill(
+  result: Record<string, CommandDefinition>,
+  keyAssignedTo: Map<string, string>,
+  slashKey: string,
+  skill: LoadedSkill,
+): void {
+  const existingOwner = keyAssignedTo.get(slashKey)
+  if (existingOwner !== undefined && existingOwner !== skill.name) {
+    log(
+      `Skill slash-key conflict: '${slashKey}' was registered by '${existingOwner}' and is being overwritten by '${skill.name}'`,
+    )
+  }
+  const { name: _name, argumentHint: _argumentHint, ...openCodeCompatible } = skill.definition
+  result[slashKey] = openCodeCompatible as CommandDefinition
+  keyAssignedTo.set(slashKey, skill.name)
+}
+
+function resolveNestedSlashKey(
+  skill: LoadedSkill,
+  keyAssignedTo: Map<string, string>,
+): string {
+  if (!skill.flatName) {
+    return skill.name
+  }
+
+  const flat = skill.flatName
+  const existingOwner = keyAssignedTo.get(flat)
+  if (existingOwner === undefined || existingOwner === skill.name) {
+    return flat
+  }
+
+  log(
+    `Flat slash name collision for nested skill '${flat}' (owners: '${existingOwner}' and '${skill.name}'); falling back to prefixed path for '${skill.name}'`,
+  )
+  return skill.name
 }

--- a/src/features/opencode-skill-loader/skill-directory-loader.test.ts
+++ b/src/features/opencode-skill-loader/skill-directory-loader.test.ts
@@ -57,4 +57,73 @@ describe("loadSkillsFromDir", () => {
       "parent/nested-child",
     ]);
   });
+
+  it("marks top-level skills with depth 0 and nested skills with depth 1 and flatName", async () => {
+    // given
+    const tempDir = mkdtempSync(join(tmpdir(), "omo-skill-directory-loader-"));
+    tempDirs.push(tempDir);
+    const rootSkillsDir = join(tempDir, "skills");
+
+    writeSkill(join(rootSkillsDir, "parent"), "parent", "Parent description");
+    writeSkill(
+      join(rootSkillsDir, "parent", "child"),
+      "child",
+      "Child description",
+    );
+
+    // when
+    const loadedSkills = await loadSkillsFromDir({
+      skillsDir: rootSkillsDir,
+      scope: "user",
+      maxDepth: 2,
+    });
+
+    // then
+    const byName = new Map(loadedSkills.map((skill) => [skill.name, skill]));
+    const parent = byName.get("parent");
+    const child = byName.get("parent/child");
+
+    expect(parent?.depth).toBe(0);
+    expect(parent?.flatName).toBeUndefined();
+
+    expect(child?.depth).toBe(1);
+    expect(child?.flatName).toBe("child");
+  });
+
+  it("reads user-invocable from SKILL.md frontmatter", async () => {
+    // given
+    const tempDir = mkdtempSync(join(tmpdir(), "omo-skill-directory-loader-"));
+    tempDirs.push(tempDir);
+    const rootSkillsDir = join(tempDir, "skills");
+
+    mkdirSync(join(rootSkillsDir, "hidden-skill"), { recursive: true });
+    writeFileSync(
+      join(rootSkillsDir, "hidden-skill", "SKILL.md"),
+      `---\nname: hidden-skill\ndescription: Hidden from slash\nuser-invocable: false\n---\nBody\n`,
+    );
+
+    mkdirSync(join(rootSkillsDir, "visible-skill"), { recursive: true });
+    writeFileSync(
+      join(rootSkillsDir, "visible-skill", "SKILL.md"),
+      `---\nname: visible-skill\ndescription: Visible in slash\nuser-invocable: true\n---\nBody\n`,
+    );
+
+    mkdirSync(join(rootSkillsDir, "default-skill"), { recursive: true });
+    writeFileSync(
+      join(rootSkillsDir, "default-skill", "SKILL.md"),
+      `---\nname: default-skill\ndescription: No user-invocable field\n---\nBody\n`,
+    );
+
+    // when
+    const loadedSkills = await loadSkillsFromDir({
+      skillsDir: rootSkillsDir,
+      scope: "user",
+    });
+
+    // then
+    const byName = new Map(loadedSkills.map((s) => [s.name, s]));
+    expect(byName.get("hidden-skill")?.userInvocable).toBe(false);
+    expect(byName.get("visible-skill")?.userInvocable).toBe(true);
+    expect(byName.get("default-skill")?.userInvocable).toBeUndefined();
+  });
 });

--- a/src/features/opencode-skill-loader/skill-directory-loader.ts
+++ b/src/features/opencode-skill-loader/skill-directory-loader.ts
@@ -1,11 +1,8 @@
 import { promises as fs } from "fs";
-import { basename, join } from "path";
-import { resolveSymlinkAsync, isMarkdownFile } from "../../shared/file-utils";
+import { join } from "path";
+import { resolveSymlinkAsync } from "../../shared/file-utils";
 import type { LoadedSkill, SkillScope } from "./types";
-import {
-  inferSkillNameFromFileName,
-  loadSkillFromPath,
-} from "./loaded-skill-from-path";
+import { loadSkillFromPath } from "./loaded-skill-from-path";
 
 export async function loadSkillsFromDir(options: {
   skillsDir: string;
@@ -22,21 +19,11 @@ export async function loadSkillsFromDir(options: {
     .readdir(options.skillsDir, { withFileTypes: true })
     .catch(() => []);
   const skillMap = new Map<string, LoadedSkill>();
-  const currentDirName = basename(options.skillsDir);
 
   const directories = entries.filter(
     (entry) =>
       !entry.name.startsWith(".") &&
       (entry.isDirectory() || entry.isSymbolicLink()),
-  );
-  const files = entries.filter(
-    (entry) =>
-      !entry.name.startsWith(".") &&
-      !entry.isDirectory() &&
-      !entry.isSymbolicLink() &&
-      entry.name !== "SKILL.md" &&
-      entry.name !== `${currentDirName}.md` &&
-      isMarkdownFile(entry),
   );
 
   for (const entry of directories) {
@@ -61,7 +48,7 @@ export async function loadSkillsFromDir(options: {
       }
       directorySkillLoaded = true;
     } catch {
-      // no SKILL.md
+      // no SKILL.md in this directory; try {dirName}.md fallback below
     }
 
     if (!directorySkillLoaded) {
@@ -80,7 +67,7 @@ export async function loadSkillsFromDir(options: {
           skillMap.set(skill.name, skill);
         }
       } catch {
-        // no named md
+        // no entrypoint file in this directory; recurse below if depth allows
       }
     }
 
@@ -98,22 +85,6 @@ export async function loadSkillsFromDir(options: {
           skillMap.set(nestedSkill.name, nestedSkill);
         }
       }
-    }
-  }
-
-  for (const entry of files) {
-    const entryPath = join(options.skillsDir, entry.name);
-    const baseName = inferSkillNameFromFileName(entryPath);
-    const skill = await loadSkillFromPath({
-      skillPath: entryPath,
-      resolvedPath: options.skillsDir,
-      defaultName: baseName,
-      scope: options.scope,
-      namePrefix,
-      depth,
-    });
-    if (skill && !skillMap.has(skill.name)) {
-      skillMap.set(skill.name, skill);
     }
   }
 

--- a/src/features/opencode-skill-loader/skill-directory-loader.ts
+++ b/src/features/opencode-skill-loader/skill-directory-loader.ts
@@ -54,6 +54,7 @@ export async function loadSkillsFromDir(options: {
         defaultName: dirName,
         scope: options.scope,
         namePrefix,
+        depth,
       });
       if (skill && !skillMap.has(skill.name)) {
         skillMap.set(skill.name, skill);
@@ -73,6 +74,7 @@ export async function loadSkillsFromDir(options: {
           defaultName: dirName,
           scope: options.scope,
           namePrefix,
+          depth,
         });
         if (skill && !skillMap.has(skill.name)) {
           skillMap.set(skill.name, skill);
@@ -108,6 +110,7 @@ export async function loadSkillsFromDir(options: {
       defaultName: baseName,
       scope: options.scope,
       namePrefix,
+      depth,
     });
     if (skill && !skillMap.has(skill.name)) {
       skillMap.set(skill.name, skill);

--- a/src/features/opencode-skill-loader/types.ts
+++ b/src/features/opencode-skill-loader/types.ts
@@ -15,6 +15,19 @@ export interface SkillMetadata {
   metadata?: Record<string, string>
   "allowed-tools"?: string | string[]
   mcp?: SkillMcpConfig
+  /**
+   * Claude Code spec field. When false, the skill is hidden from the
+   * slash-command picker. The skill remains callable by agents via the
+   * skill tool and via load_skills delegation. Defaults to true per
+   * spec (https://docs.claude.com/en/docs/claude-code/skills).
+   */
+  "user-invocable"?: boolean
+  /**
+   * Claude Code spec field. When true, the model cannot auto-invoke
+   * this skill; it must be called manually by the user. Defaults to
+   * false per spec.
+   */
+  "disable-model-invocation"?: boolean
 }
 
 export interface LazyContentLoader {
@@ -35,4 +48,27 @@ export interface LoadedSkill {
   allowedTools?: string[]
   mcpConfig?: SkillMcpConfig
   lazyContent?: LazyContentLoader
+  /**
+   * Depth at which this skill was discovered (0 = top-level inside a
+   * skills root; 1+ = nested inside another skill's directory). Used by
+   * registration filters that honor the OmO skills.hide_nested_by_default
+   * inversion flag.
+   */
+  depth?: number
+  /**
+   * Resolved visibility in the slash-command picker. Derived at load
+   * time from the Claude Code `user-invocable` frontmatter field (default
+   * true) XOR'd with the OmO `skills.hide_nested_by_default` inversion
+   * flag when the skill is nested. Non-invocable skills remain callable
+   * via the skill tool and load_skills delegation; only the slash menu
+   * is affected.
+   */
+  userInvocable?: boolean
+  /**
+   * Short frontmatter name without the parent-directory prefix. Set
+   * for nested skills so registration can present them under a clean
+   * flat slash name (/child) instead of the path-prefixed unique name
+   * (/parent/child) used internally for deduplication.
+   */
+  flatName?: string
 }

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -1,4 +1,4 @@
-import type { OhMyOpenCodeConfig } from "../config";
+import type { OhMyOpenCodeConfig, SkillsConfig } from "../config";
 import {
   getAgentConfigKey,
   getAgentListDisplayName,
@@ -49,6 +49,9 @@ export async function applyCommandConfig(params: {
     log(getSkillPluginConflictWarning(externalSkillPlugin.pluginName!));
   }
 
+  const hideNestedByDefault = resolveHideNestedByDefault(params.pluginConfig.skills);
+  const slashOptions = { hideNestedByDefault };
+
   const [
     configSourceSkills,
     userCommands,
@@ -70,17 +73,17 @@ export async function applyCommandConfig(params: {
     includeClaudeCommands ? loadProjectCommands(params.ctx.directory) : Promise.resolve({}),
     loadOpencodeGlobalCommands(),
     loadOpencodeProjectCommands(params.ctx.directory),
-    includeClaudeSkills ? loadUserSkills() : Promise.resolve({}),
-    includeAgentsSkills ? loadGlobalAgentsSkills() : Promise.resolve({}),
-    includeClaudeSkills ? loadProjectSkills(params.ctx.directory) : Promise.resolve({}),
-    includeAgentsSkills ? loadProjectAgentsSkills(params.ctx.directory) : Promise.resolve({}),
-    loadOpencodeGlobalSkills(),
-    loadOpencodeProjectSkills(params.ctx.directory),
+    includeClaudeSkills ? loadUserSkills(slashOptions) : Promise.resolve({}),
+    includeAgentsSkills ? loadGlobalAgentsSkills(slashOptions) : Promise.resolve({}),
+    includeClaudeSkills ? loadProjectSkills(params.ctx.directory, slashOptions) : Promise.resolve({}),
+    includeAgentsSkills ? loadProjectAgentsSkills(params.ctx.directory, slashOptions) : Promise.resolve({}),
+    loadOpencodeGlobalSkills(slashOptions),
+    loadOpencodeProjectSkills(params.ctx.directory, slashOptions),
   ]);
 
   params.config.command = {
     ...builtinCommands,
-    ...skillsToCommandDefinitionRecord(configSourceSkills),
+    ...skillsToCommandDefinitionRecord(configSourceSkills, slashOptions),
     ...userCommands,
     ...userSkills,
     ...globalAgentsSkills,
@@ -105,4 +108,12 @@ function remapCommandAgentFields(commands: Record<string, Record<string, unknown
       cmd.agent = getAgentListDisplayName(getAgentConfigKey(cmd.agent));
     }
   }
+}
+
+function resolveHideNestedByDefault(skillsConfig: SkillsConfig | undefined): boolean {
+  if (!skillsConfig || Array.isArray(skillsConfig) || typeof skillsConfig !== "object") {
+    return false;
+  }
+  const value = (skillsConfig as { hide_nested_by_default?: unknown }).hide_nested_by_default;
+  return value === true;
 }


### PR DESCRIPTION
## Summary

Implements Claude Code skill frontmatter fields that OmO was parsing-into-types but not acting on, and adds an OmO-level inversion flag to handle nested-skill bloat at scale.

**Spec compliance:**
- Reads `user-invocable` from SKILL.md frontmatter. When `false`, the skill is hidden from the slash-command picker. Still fully callable via the skill tool, UI Skills picker, and `load_skills` delegation.
- Reads `disable-model-invocation` from SKILL.md frontmatter (parsed; no filter wired yet — see follow-up).

**OmO inversion flag:**
- Adds `skills.hide_nested_by_default: boolean` to `opencode.json`. When true, inverts the Claude Code spec default (`user-invocable: true`) for **nested skills only**. Top-level skills are unaffected.
- Rationale: large skill hubs (quality-standard, reverse-engineering, etc.) ship many child skills meant as supporting routines, not standalone slash commands. Flipping the flag once replaces per-SKILL.md opt-out work with per-SKILL.md opt-in.
- Explicit frontmatter always wins over the inversion.

**Collision handling:** when two nested skills share the same flat name, the first wins; subsequent ones fall back to their path-prefixed unique name and a log warning fires.

## Test Plan

- New test file `skill-definition-record.test.ts` with 8 cases
- Extended `skill-directory-loader.test.ts` with 2 new cases
- `bun run typecheck` — clean
- Full suite: 5612/5612 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the Claude Code `user-invocable` field and adds a workspace flag to hide nested skills by default, reducing slash-command noise. Aligns discovery with the spec by indexing only directory skills with `SKILL.md`.

- **New Features**
  - Respects `user-invocable` from `SKILL.md`. When `false`, the skill is hidden from the slash picker but still callable by tools, UI picker, and `load_skills`.
  - Adds `skills.hide_nested_by_default` in `opencode.json`. It hides nested skills unless they set `user-invocable: true`. Top-level skills are unaffected. Frontmatter always wins.
  - Registers visible nested skills under their flat name (e.g., `/child`). On collision, falls back to the path name (e.g., `/parent/child`) and logs a warning.
  - Parses `disable-model-invocation` for future use.
  - Propagates the slash-visibility option through `loadUserSkills`, `loadProjectSkills`, `loadOpencodeGlobalSkills`, `loadOpencodeProjectSkills`, `loadGlobalAgentsSkills`, and config-sourced skills.

- **Bug Fixes**
  - Only indexes directory skills with `SKILL.md` per spec. Bare `.md` files are ignored. The `{dirName}.md` fallback remains supported.
  - Tightened discovery tests and added cases for nesting, visibility, and collisions.

<sup>Written for commit b32cbcc9fb3940de50e61f36379256276652527b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

