### PR TITLE
fix(skill-loader): only index SKILL.md directories as skills, per Anthropic spec

### DIFF
--- a/src/features/opencode-skill-loader/async-loader.test.ts
+++ b/src/features/opencode-skill-loader/async-loader.test.ts
@@ -88,8 +88,11 @@ Skill body.
       expect(skills[0].name).toBe("named-skill")
     })
 
-    it("discovers direct .md files", async () => {
-      // given
+    it("ignores direct .md files at the skills root (not a SKILL.md entrypoint)", async () => {
+      // given — plain markdown file directly under the skills root.
+      // Per the Anthropic Agent Skills spec, a skill is a directory
+      // containing SKILL.md. A bare .md file is supporting material,
+      // not a skill, so discovery must skip it.
       const skillContent = `---
 name: direct-skill
 description: Direct markdown file
@@ -103,8 +106,7 @@ Direct skill.
       const skills = await discoverSkillsInDirAsync(SKILLS_DIR)
 
       // then
-      expect(skills).toHaveLength(1)
-      expect(skills[0].name).toBe("direct-skill")
+      expect(skills).toHaveLength(0)
     })
 
     it("preserves nested skill path names during recursive discovery", async () => {
@@ -155,8 +157,11 @@ Nested skill.
       expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
     })
 
-    it("preserves nested skill path names for nested direct markdown discovery", async () => {
-      // given
+    it("ignores sibling .md files inside a nested directory that lacks SKILL.md or {dirName}.md", async () => {
+      // given — a nested directory holding only a plain .md file with
+      // neither a SKILL.md entrypoint nor a {dirName}.md fallback.
+      // Discovery must recurse but find no invocable skill, since
+      // supporting .md files are not skills per spec.
       const nestedSkillDir = join(SKILLS_DIR, "superpowers")
       mkdirSync(nestedSkillDir, { recursive: true })
       writeFileSync(
@@ -174,9 +179,7 @@ Nested skill.
       const skills = await discoverSkillsInDirAsync(SKILLS_DIR)
 
       // then
-      expect(skills).toHaveLength(1)
-      expect(skills[0]?.name).toBe("superpowers/brainstorming")
-      expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
+      expect(skills).toHaveLength(0)
     })
 
     it("skips entries starting with dot", async () => {

--- a/src/features/opencode-skill-loader/async-loader.ts
+++ b/src/features/opencode-skill-loader/async-loader.ts
@@ -163,46 +163,58 @@ export async function discoverSkillsInDirAsync(
     const processEntry = async (entry: Dirent): Promise<LoadedSkill | LoadedSkill[] | null> => {
       if (entry.name.startsWith(".")) return null
 
+      if (!(entry.isDirectory() || entry.isSymbolicLink())) {
+        return null
+      }
+
       const entryPath = join(skillsDir, entry.name)
+      const resolvedPath = resolveSymlink(entryPath)
+      const dirName = entry.name
 
-      if (entry.isDirectory() || entry.isSymbolicLink()) {
-        const resolvedPath = resolveSymlink(entryPath)
-        const dirName = entry.name
-
-        const skillMdPath = join(resolvedPath, "SKILL.md")
-        try {
-          await readFile(skillMdPath, "utf-8")
-          return await loadSkillFromPathAsync(skillMdPath, resolvedPath, dirName, scope, namePrefix)
-        } catch {
-          const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
-          try {
-            await readFile(namedSkillMdPath, "utf-8")
-            return await loadSkillFromPathAsync(namedSkillMdPath, resolvedPath, dirName, scope, namePrefix)
-          } catch {
-            if (depth >= maxDepth) {
-              return null
-            }
-
-            const nestedPrefix = namePrefix ? `${namePrefix}/${dirName}` : dirName
-            const nestedSkills = await discoverSkillsInDirAsync(
-              resolvedPath,
-              scope,
-              nestedPrefix,
-              depth + 1,
-              maxDepth
-            )
-
-            return nestedSkills.length > 0 ? nestedSkills : null
-          }
-        }
+      const skillMdPath = join(resolvedPath, "SKILL.md")
+      try {
+        await readFile(skillMdPath, "utf-8")
+        return await loadSkillFromPathAsync(
+          skillMdPath,
+          resolvedPath,
+          dirName,
+          scope,
+          namePrefix,
+          depth,
+        )
+      } catch {
+        // fall through to {dirName}.md fallback and recursive descent
       }
 
-      if (isMarkdownFile(entry)) {
-        const skillName = basename(entry.name, ".md")
-        return await loadSkillFromPathAsync(entryPath, skillsDir, skillName, scope, namePrefix)
+      const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
+      try {
+        await readFile(namedSkillMdPath, "utf-8")
+        return await loadSkillFromPathAsync(
+          namedSkillMdPath,
+          resolvedPath,
+          dirName,
+          scope,
+          namePrefix,
+          depth,
+        )
+      } catch {
+        // no entrypoint in this directory; recurse if depth allows
       }
 
-      return null
+      if (depth >= maxDepth) {
+        return null
+      }
+
+      const nestedPrefix = namePrefix ? `${namePrefix}/${dirName}` : dirName
+      const nestedSkills = await discoverSkillsInDirAsync(
+        resolvedPath,
+        scope,
+        nestedPrefix,
+        depth + 1,
+        maxDepth,
+      )
+
+      return nestedSkills.length > 0 ? nestedSkills : null
     }
 
     const skillPromises = await mapWithConcurrency(entries, processEntry, 16)

--- a/src/features/opencode-skill-loader/blocking.test.ts
+++ b/src/features/opencode-skill-loader/blocking.test.ts
@@ -17,13 +17,13 @@ afterEach(() => {
 
 describe("discoverAllSkillsBlocking", () => {
   it("returns skills synchronously from valid directories", () => {
-    // given valid skill directory
-    const skillDir = join(TEST_DIR, "skills")
+    // given a skill directory with a proper SKILL.md entrypoint
+    const skillsRoot = join(TEST_DIR, "skills")
+    const skillDir = join(skillsRoot, "test-skill")
     mkdirSync(skillDir, { recursive: true })
 
-    const skillMdPath = join(skillDir, "test-skill.md")
     writeFileSync(
-      skillMdPath,
+      join(skillDir, "SKILL.md"),
       `---
 name: test-skill
 description: A test skill
@@ -31,7 +31,7 @@ description: A test skill
 This is test skill content.`
     )
 
-    const dirs = [skillDir]
+    const dirs = [skillsRoot]
     const scopes: SkillScope[] = ["opencode-project"]
 
     // when discoverAllSkillsBlocking called
@@ -76,14 +76,14 @@ This is test skill content.`
   })
 
   it("handles multiple directories with mixed content", () => {
-    // given multiple directories with valid and invalid skills
+    // given two skills roots, each containing one directory skill with SKILL.md
     const dir1 = join(TEST_DIR, "dir1")
     const dir2 = join(TEST_DIR, "dir2")
-    mkdirSync(dir1, { recursive: true })
-    mkdirSync(dir2, { recursive: true })
+    mkdirSync(join(dir1, "skill1"), { recursive: true })
+    mkdirSync(join(dir2, "skill2"), { recursive: true })
 
     writeFileSync(
-      join(dir1, "skill1.md"),
+      join(dir1, "skill1", "SKILL.md"),
       `---
 name: skill1
 description: First skill
@@ -92,7 +92,7 @@ Skill 1 content.`
     )
 
     writeFileSync(
-      join(dir2, "skill2.md"),
+      join(dir2, "skill2", "SKILL.md"),
       `---
 name: skill2
 description: Second skill
@@ -109,19 +109,19 @@ Skill 2 content.`
     // then returns all valid skills
     expect(skills).toBeArray()
     expect(skills.length).toBe(2)
-    
+
     const skillNames = skills.map(s => s.name).sort()
     expect(skillNames).toEqual(["skill1", "skill2"])
   })
 
   it("skips invalid YAML files", () => {
-    // given directory with invalid YAML
-    const skillDir = join(TEST_DIR, "skills")
-    mkdirSync(skillDir, { recursive: true })
+    // given a skills root with one valid and one invalid SKILL.md directory
+    const skillsRoot = join(TEST_DIR, "skills")
+    mkdirSync(join(skillsRoot, "valid-skill"), { recursive: true })
+    mkdirSync(join(skillsRoot, "invalid-skill"), { recursive: true })
 
-    const validSkillPath = join(skillDir, "valid.md")
     writeFileSync(
-      validSkillPath,
+      join(skillsRoot, "valid-skill", "SKILL.md"),
       `---
 name: valid-skill
 description: Valid skill
@@ -129,9 +129,8 @@ description: Valid skill
 Valid skill content.`
     )
 
-    const invalidSkillPath = join(skillDir, "invalid.md")
     writeFileSync(
-      invalidSkillPath,
+      join(skillsRoot, "invalid-skill", "SKILL.md"),
       `---
 name: invalid skill
 description: [ invalid yaml
@@ -139,7 +138,7 @@ description: [ invalid yaml
 Invalid content.`
     )
 
-    const dirs = [skillDir]
+    const dirs = [skillsRoot]
     const scopes: SkillScope[] = ["opencode-project"]
 
     // when discoverAllSkillsBlocking called
@@ -180,15 +179,15 @@ This is a directory-based skill.`
   })
 
   it("processes large skill sets without timeout", () => {
-    // given directory with many skills (20+)
-    const skillDir = join(TEST_DIR, "many-skills")
-    mkdirSync(skillDir, { recursive: true })
+    // given a skills root with many directory-based skills (20+)
+    const skillsRoot = join(TEST_DIR, "many-skills")
 
     const skillCount = 25
     for (let i = 0; i < skillCount; i++) {
-      const skillPath = join(skillDir, `skill-${i}.md`)
+      const skillDir = join(skillsRoot, `skill-${i}`)
+      mkdirSync(skillDir, { recursive: true })
       writeFileSync(
-        skillPath,
+        join(skillDir, "SKILL.md"),
         `---
 name: skill-${i}
 description: Skill number ${i}
@@ -197,7 +196,7 @@ Content for skill ${i}.`
       )
     }
 
-    const dirs = [skillDir]
+    const dirs = [skillsRoot]
     const scopes: SkillScope[] = ["opencode-project"]
 
     // when discoverAllSkillsBlocking called

--- a/src/features/opencode-skill-loader/skill-directory-loader.ts
+++ b/src/features/opencode-skill-loader/skill-directory-loader.ts
@@ -1,11 +1,8 @@
 import { promises as fs } from "fs";
-import { basename, join } from "path";
-import { resolveSymlinkAsync, isMarkdownFile } from "../../shared/file-utils";
+import { join } from "path";
+import { resolveSymlinkAsync } from "../../shared/file-utils";
 import type { LoadedSkill, SkillScope } from "./types";
-import {
-  inferSkillNameFromFileName,
-  loadSkillFromPath,
-} from "./loaded-skill-from-path";
+import { loadSkillFromPath } from "./loaded-skill-from-path";
 
 export async function loadSkillsFromDir(options: {
   skillsDir: string;
@@ -22,21 +19,11 @@ export async function loadSkillsFromDir(options: {
     .readdir(options.skillsDir, { withFileTypes: true })
     .catch(() => []);
   const skillMap = new Map<string, LoadedSkill>();
-  const currentDirName = basename(options.skillsDir);
 
   const directories = entries.filter(
     (entry) =>
       !entry.name.startsWith(".") &&
       (entry.isDirectory() || entry.isSymbolicLink()),
-  );
-  const files = entries.filter(
-    (entry) =>
-      !entry.name.startsWith(".") &&
-      !entry.isDirectory() &&
-      !entry.isSymbolicLink() &&
-      entry.name !== "SKILL.md" &&
-      entry.name !== `${currentDirName}.md` &&
-      isMarkdownFile(entry),
   );
 
   for (const entry of directories) {
@@ -61,7 +48,7 @@ export async function loadSkillsFromDir(options: {
       }
       directorySkillLoaded = true;
     } catch {
-      // no SKILL.md
+      // no SKILL.md in this directory; try {dirName}.md fallback below
     }
 
     if (!directorySkillLoaded) {
@@ -80,7 +67,7 @@ export async function loadSkillsFromDir(options: {
           skillMap.set(skill.name, skill);
         }
       } catch {
-        // no named md
+        // no entrypoint file in this directory; recurse below if depth allows
       }
     }
 
@@ -98,22 +85,6 @@ export async function loadSkillsFromDir(options: {
           skillMap.set(nestedSkill.name, nestedSkill);
         }
       }
-    }
-  }
-
-  for (const entry of files) {
-    const entryPath = join(options.skillsDir, entry.name);
-    const baseName = inferSkillNameFromFileName(entryPath);
-    const skill = await loadSkillFromPath({
-      skillPath: entryPath,
-      resolvedPath: options.skillsDir,
-      defaultName: baseName,
-      scope: options.scope,
-      namePrefix,
-      depth,
-    });
-    if (skill && !skillMap.has(skill.name)) {
-      skillMap.set(skill.name, skill);
     }
   }
 


### PR DESCRIPTION
## Summary

Stops indexing bare `.md` files inside skills directories as skills. Per the [Anthropic Agent Skills specification](https://agentskills.io/specification), a skill is a directory containing SKILL.md. Sibling `.md` files are supporting material, referenced via `@path` from the parent SKILL.md.

**Affects both discovery paths:**
- `skill-directory-loader.ts` (serial async)
- `async-loader.ts` (concurrency-16 async)

**Preserved:**
- `{dirName}.md` fallback (OmO extension: a directory without SKILL.md can declare a skill via a file named after the directory)
- Config-source single-file skills via `skills.sources` in `opencode.json`

**User impact:** skills like `tui-use-vim-test/tests/substitute.md` stop appearing in the slash picker. They were never meant to be slash-invocable.

## Base branch

Stacked on `feat/honor-user-invocable-spec` because it depends on the `depth` parameter added to `loadSkillFromPath` there. After the base merges, this PR rebases cleanly onto `dev`.

## Test Plan

- 2 tests flipped assertions ("discovers direct .md files" → "ignores direct .md files")
- 4 tests restructured fixtures from `dir/skill-N.md` to `dir/skill-N/SKILL.md`
- `bun run typecheck` — clean
- Full suite: 5612/5612 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Index only directory-based skills with `SKILL.md` (or `{dirName}.md` fallback) during discovery, per the Anthropic Agent Skills spec. Bare `.md` files inside skills directories are now ignored, so non-entrypoint docs no longer show in the slash picker.

- **Bug Fixes**
  - Updated `skill-directory-loader.ts` and `async-loader.ts` to load only `SKILL.md` or `{dirName}.md`; skip standalone `.md` files under skills roots.
  - Preserved `{dirName}.md` fallback and `skills.sources` single-file paths in `opencode.json`.
  - Updated tests to use `dir/SKILL.md` fixtures and flipped two assertions.

<sup>Written for commit b28b73db5e2631708e469dd7df946ea81616e9a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

