### PR TITLE
fix: address PR review feedback + fix flaky countdown toast test

### DIFF
--- a/docs/SYNC_METHODOLOGY.md
+++ b/docs/SYNC_METHODOLOGY.md
@@ -18,7 +18,7 @@ rejecting, or citing any upstream commit, read the file list and the line
 counts. Form the judgment from what the commit DOES, not what its title SAYS.
 
 Worked example. Upstream PR #868 ("feat/deepwiki", merged as `987ae468`)
-modifies exactly one file: `README.md`, one line added — a
+modifies exactly one file: `README.md`, one line added -- a
 [deepwiki.com](https://deepwiki.com) badge pointing to the auto-generated wiki
 for `code-yeongyu/oh-my-openagent`. There is no source code, no MCP server, no
 tool registration, no plugin wiring. A title-only read invites the conclusion
@@ -29,7 +29,7 @@ diff itself carries the weight.
 
 The rule generalizes. The analyzer's classifier (§6) scores each commit on
 what its diff contains, not on its title or commit message. Maintainers must
-apply the same discipline manually when reviewing the analyzer's draft PRs —
+apply the same discipline manually when reviewing the analyzer's draft PRs --
 especially for the `-good` batch, where a charitable title can smuggle in
 admin-only or churn-only commits that the file-list reveals immediately.
 
@@ -39,11 +39,11 @@ admin-only or churn-only commits that the file-list reveals immediately.
 | --- | --- |
 | Published version | `@vacbo/oh-my-opencode@3.18.0` |
 | Last upstream tag synced (`upstream-version.txt`) | `v3.17.0` |
-| Latest upstream stable tag | `v3.18.0` |
+| Latest upstream stable tag | `v3.17.4` |
 | Fork `dev` vs `upstream/dev` | 43 ahead / 60 behind |
 | Sync pipeline | `upstream-tag-watcher.yml` + `upstream-analyzer.yml` (3-pass AI classifier) |
 | Release pipeline | `publish.yml` (main package + 11 platform binaries + GitHub release) |
-| Legacy pipeline | `sync-upstream.yml` — **disabled**, kept for reference |
+| Legacy pipeline | `sync-upstream.yml` -- **disabled**, kept for reference |
 | Slop rubric | `.github/prompts/{commit-classify,slop-verify,release-synthesis}.md` |
 | Deviation register | `docs/fork-deviations.md` |
 
@@ -76,21 +76,24 @@ Providers and chains are configured in `upstream-analyzer.yml` workflow inputs
 and `script/upstream-analyzer/providers.ts`. Default chain order is best-free
 first (OpenRouter → NVIDIA → GitHub Models).
 
-## 3. Manual gate — the six steps after the analyzer fires
+## 3. Manual gate -- the six steps after the analyzer fires
 
 ### Step A. Triage the analysis issue
 
 The analyzer opens a labeled issue with the release-level verdict. Read it
-before touching any PR. If the verdict is "mostly slop" across the window, you
-can legitimately skip this upstream release entirely — leave
-`upstream-version.txt` at its current value so the next analyzer run includes
-the skipped commits in a wider window.
+before touching any PR. If the verdict is "mostly slop" across the window you
+still need to advance `upstream-version.txt` to the inspected tag after you
+close the draft PRs; the `upstream-tag-watcher.yml` cron reads that file and
+will re-dispatch the analyzer every 15 minutes for as long as the tracker
+stays behind the latest upstream tag. Either advance the tracker and let the
+next upstream tag kick off a fresh window, or temporarily record the skipped
+tag in `.upstream-watcher-seen-tag` so the watcher does not keep firing.
 
 ### Step B. Process the `-good` batch
 
 Default: merge after CI passes.
 
-Exception — **the classifier is known to be charitable** on administrative
+Exception -- **the classifier is known to be charitable** on administrative
 commits. Before merging, scan the batch for and drop:
 
 - CLA signature commits (`@X has signed the CLA in code-yeongyu/...`)
@@ -132,7 +135,9 @@ The workflow:
 3. Publishes `@vacbo/oh-my-opencode` with provenance
 4. Builds and publishes 11 platform binaries
 5. Tags `v{version}`, generates changelog, creates GitHub release
-6. Merges `dev` → `master`
+6. Resets `master` to the new release tag and force-pushes (the workflow does
+   `git checkout master && git reset --hard v{version} && git push -f origin master`;
+   it does not create a `dev` to `master` merge commit)
 
 ## 4. Fork-only fixes (changes that do not come from upstream)
 
@@ -140,13 +145,13 @@ Path:
 
 1. Branch from `dev`: `feat/<scope>`, `fix/<scope>`, or `docs/<scope>`.
 2. PR to `dev` (not `master`). Reviewer applies the same slop rubric as upstream
-   commits — see §6.
+   commits -- see §6.
 3. CI gates: `bun test`, `bun run typecheck`, publish workflow smoke tests.
 4. On merge, add a row to `docs/fork-deviations.md` with the SHA, category,
    reason, and upstream plan (see §7).
 5. Next `publish.yml` dispatch folds the change into a release.
 
-Fork-only fixes must not land on `sync/upstream/*` branches — those are reserved
+Fork-only fixes must not land on `sync/upstream/*` branches -- those are reserved
 for upstream cherry-picks so the analyzer's lineage tracking stays clean.
 
 ## 5. Conflict resolution
@@ -156,7 +161,7 @@ When a `sync/upstream/{tag}-{verdict}` cherry-pick conflicts:
 | Conflict type | Rule |
 | --- | --- |
 | Upstream changed a file we rewrote for slop | Prefer fork version. Re-classify upstream's change in next window. |
-| Upstream fixed a bug in code we no longer have | Drop the commit — not applicable. |
+| Upstream fixed a bug in code we no longer have | Drop the commit -- not applicable. |
 | Upstream feature collides with a fork-only feature | Prefer fork version. Open an issue to either port the upstream approach or justify the permanent delta. |
 | Trivial formatting / line endings / timestamps | Take either side; auto-resolve if possible. |
 
@@ -165,7 +170,7 @@ work, stop and record it as a divergence-tax data point in a comment on the
 draft PR. Repeated high-tax conflicts are a signal that the relevant fork
 patches should be proposed upstream or reconsidered.
 
-## 6. Anti-slop checklist (apply to every PR — upstream-origin or fork-origin)
+## 6. Anti-slop checklist (apply to every PR -- upstream-origin or fork-origin)
 
 Default to NEEDS_REVIEW when unsure. 60 seconds of human read is cheaper than a
 permanent slop merge.
@@ -194,7 +199,7 @@ Category-first taxonomy (apply before the verdict):
 | Code-value | `real_bug_fix`, `real_test`, `real_feature`, `refactor_with_clear_value` | GOOD |
 | Suspicious | `refactor_churn`, `docs_churn`, `minor_visibility_churn`, `workflow_or_tooling_maze` | Lean SLOP |
 | Admin | `cla_admin`, `release_version_bump`, `governance_noise`, `date_count_metadata_churn` | Never GOOD |
-| Unclear | — | NEEDS_REVIEW |
+| Unclear | -- | NEEDS_REVIEW |
 
 The canonical rubric lives in `.github/prompts/commit-classify.md`. This table
 is a human-facing summary; the prompt file is the source of truth.
@@ -244,12 +249,12 @@ when you have something a user would notice.
 
 ## 10. What this document deliberately excludes
 
-- The analyzer's internal prompt engineering — owned by `.github/prompts/`.
+- The analyzer's internal prompt engineering -- owned by `.github/prompts/`.
 - The OmO source-code diagnostic plan (slop + performance audit of this fork
-  itself) — owned by `p10`, blocked on the diagnostic from `p9`.
-- The opencode-fork feasibility study — owned by `p11`.
+  itself) -- owned by `p10`, blocked on the diagnostic from `p9`.
+- The opencode-fork feasibility study -- owned by `p11`.
 - Any changes to tool routing for subagents (WarpGrep, DeepWiki, GitHub MCP,
-  recursion depth) — separate research track, out of scope for sync methodology.
+  recursion depth) -- separate research track, out of scope for sync methodology.
 
 ## 11. Immediate backlog (as of 2026-04-21)
 
@@ -257,12 +262,14 @@ Ordered by dependency.
 
 - [ ] Bump `upstream-version.txt` → `v3.17.4` to reflect what was actually
       synced in the p9 window (per handoff plan §Context, lines 45-51).
-- [ ] Dispatch the analyzer for `v3.17.4 → v3.18.0` to catch up on the
+- [ ] Dispatch the analyzer for `v3.17.4 -> upstream/dev` to catch up on the
       60-commit gap on `upstream/dev`.
 - [ ] Review the 3 draft PRs it produces, applying §3 Steps B-D.
-- [ ] Bump `upstream-version.txt` → `v3.18.0` after the merge decisions
-      conclude.
-- [ ] Dispatch `publish.yml` with `bump: patch` → `@vacbo/oh-my-opencode@3.18.1`.
+- [ ] Bump `upstream-version.txt` to the newly-inspected tag after the merge
+      decisions conclude.
+- [ ] Dispatch `publish.yml` with the appropriate `bump` (the feature work in
+      `user-invocable` + `hide_nested_by_default` warrants `minor`; pure bugfix
+      or doc windows warrant `patch`).
 - [ ] Optional: extend the analyzer with a pass over upstream's
       closed-unmerged PRs (§8 future work).
 - [ ] Optional: turn the slop rubric inward onto this fork's own commits

--- a/docs/fork-deviations.md
+++ b/docs/fork-deviations.md
@@ -15,9 +15,9 @@ At snapshot time: 43 commits.
 
 | Category | Meaning | Never-upstream? |
 | --- | --- | --- |
-| `analyzer-infra` | AI-powered upstream-release analyzer (tool, CI workflows, prompts) | Yes — fork-specific automation |
-| `scoped-package` | Switch from `oh-my-opencode` to `@vacbo/oh-my-opencode` scope, trusted publishing, ancillary test/doc fixes | Yes — fork identity |
-| `sync-cherrypick` | Cherry-picked from upstream in a prior sync window; stays on fork until formal tag sync | No — already upstream, just not yet rebased-over |
+| `analyzer-infra` | AI-powered upstream-release analyzer (tool, CI workflows, prompts) | Yes -- fork-specific automation |
+| `scoped-package` | Switch from `oh-my-opencode` to `@vacbo/oh-my-opencode` scope, trusted publishing, ancillary test/doc fixes | Yes -- fork identity |
+| `sync-cherrypick` | Cherry-picked from upstream in a prior sync window; stays on fork until formal tag sync | No -- already upstream, just not yet rebased-over |
 | `fork-only-fix` | Bug fix or behavior change authored here that is not present upstream | Try-to-upstream or never-upstream, per-commit |
 | `ci-hardening` | Generic CI maintenance (action version bumps, retry logic) | Usually try-to-upstream |
 | `release-bot` | `release: vX.Y.Z` commits the `publish.yml` workflow writes | Never-upstream (per-fork release tracking) |

--- a/src/config/schema/agent-names.test.ts
+++ b/src/config/schema/agent-names.test.ts
@@ -55,6 +55,17 @@ describe("OhMyOpenCodeConfigSchema disabled_skills", () => {
     // then
     expect(result.success).toBe(false)
   })
+
+  test("rejects whitespace-only strings", () => {
+    // given
+    const config = { disabled_skills: ["   ", "\t\n"] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
 })
 
 describe("OhMyOpenCodeConfigSchema disabled_commands", () => {
@@ -92,6 +103,17 @@ describe("OhMyOpenCodeConfigSchema disabled_commands", () => {
   test("rejects empty strings", () => {
     // given
     const config = { disabled_commands: [""] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("rejects whitespace-only strings", () => {
+    // given
+    const config = { disabled_commands: ["  "] }
 
     // when
     const result = OhMyOpenCodeConfigSchema.safeParse(config)

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -22,6 +22,12 @@ import { TmuxConfigSchema } from "./tmux"
 import { StartWorkConfigSchema } from "./start-work"
 import { WebsearchConfigSchema } from "./websearch"
 
+const NonBlankStringSchema = z
+  .string()
+  .refine((value) => value.trim().length > 0, {
+    message: "must not be empty or whitespace-only",
+  })
+
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),
   /** Enable new task system (default: false) */
@@ -33,18 +39,19 @@ export const OhMyOpenCodeConfigSchema = z.object({
   disabled_mcps: z.array(AnyMcpNameSchema).optional(),
   disabled_agents: z.array(z.string()).optional(),
   /**
-   * Skills to hide from discovery. Accepts any skill name — not just builtins.
+   * Skills to hide from discovery. Accepts any skill name, not just builtins.
    * Matches against the skill's registered name (e.g. "review-work",
    * "qs-anti-patterns", or user-installed skill names). Unknown names are a
-   * silent no-op so stale entries don't break config parsing.
+   * silent no-op so stale entries don't break config parsing. Whitespace-only
+   * strings are rejected so typos surface during config validation.
    */
-  disabled_skills: z.array(z.string().min(1)).optional(),
+  disabled_skills: z.array(NonBlankStringSchema).optional(),
   disabled_hooks: z.array(z.string()).optional(),
   /**
-   * Commands to hide. Accepts any command name — not just builtins. Unknown
-   * names are a silent no-op.
+   * Commands to hide. Accepts any command name, not just builtins. Unknown
+   * names are a silent no-op. Whitespace-only strings are rejected.
    */
-  disabled_commands: z.array(z.string().min(1)).optional(),
+  disabled_commands: z.array(NonBlankStringSchema).optional(),
   /** Disable specific tools by name (e.g., ["todowrite", "todoread"]) */
   disabled_tools: z.array(z.string()).optional(),
   mcp_env_allowlist: z.array(z.string()).optional(),

--- a/src/features/opencode-skill-loader/async-loader.test.ts
+++ b/src/features/opencode-skill-loader/async-loader.test.ts
@@ -89,7 +89,7 @@ Skill body.
     })
 
     it("ignores direct .md files at the skills root (not a SKILL.md entrypoint)", async () => {
-      // given — plain markdown file directly under the skills root.
+      // given - plain markdown file directly under the skills root.
       // Per the Anthropic Agent Skills spec, a skill is a directory
       // containing SKILL.md. A bare .md file is supporting material,
       // not a skill, so discovery must skip it.
@@ -158,7 +158,7 @@ Nested skill.
     })
 
     it("ignores sibling .md files inside a nested directory that lacks SKILL.md or {dirName}.md", async () => {
-      // given — a nested directory holding only a plain .md file with
+      // given - a nested directory holding only a plain .md file with
       // neither a SKILL.md entrypoint nor a {dirName}.md fallback.
       // Discovery must recurse but find no invocable skill, since
       // supporting .md files are not skills per spec.

--- a/src/features/opencode-skill-loader/async-loader.ts
+++ b/src/features/opencode-skill-loader/async-loader.ts
@@ -1,10 +1,10 @@
 import { readFile, readdir } from "fs/promises"
 import type { Dirent } from "fs"
-import { join, basename } from "path"
+import { join } from "path"
 import yaml from "js-yaml"
 import { parseFrontmatter } from "../../shared/frontmatter"
 import { sanitizeModelField } from "../../shared/model-sanitizer"
-import { resolveSymlink, isMarkdownFile } from "../../shared/file-utils"
+import { resolveSymlink } from "../../shared/file-utils"
 import { resolveSkillPathReferences } from "../../shared/skill-path-resolver"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { SkillScope, SkillMetadata, LoadedSkill } from "./types"
@@ -170,11 +170,12 @@ export async function discoverSkillsInDirAsync(
       const entryPath = join(skillsDir, entry.name)
       const resolvedPath = resolveSymlink(entryPath)
       const dirName = entry.name
+      const collected: LoadedSkill[] = []
 
       const skillMdPath = join(resolvedPath, "SKILL.md")
       try {
         await readFile(skillMdPath, "utf-8")
-        return await loadSkillFromPathAsync(
+        const loaded = await loadSkillFromPathAsync(
           skillMdPath,
           resolvedPath,
           dirName,
@@ -182,39 +183,44 @@ export async function discoverSkillsInDirAsync(
           namePrefix,
           depth,
         )
+        if (loaded) collected.push(loaded)
       } catch {
-        // fall through to {dirName}.md fallback and recursive descent
+        // no SKILL.md at this path; try {dirName}.md fallback next
       }
 
-      const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
-      try {
-        await readFile(namedSkillMdPath, "utf-8")
-        return await loadSkillFromPathAsync(
-          namedSkillMdPath,
+      if (collected.length === 0) {
+        const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
+        try {
+          await readFile(namedSkillMdPath, "utf-8")
+          const loaded = await loadSkillFromPathAsync(
+            namedSkillMdPath,
+            resolvedPath,
+            dirName,
+            scope,
+            namePrefix,
+            depth,
+          )
+          if (loaded) collected.push(loaded)
+        } catch {
+          // no entrypoint in this directory; rely on recursion below
+        }
+      }
+
+      if (depth < maxDepth) {
+        const nestedPrefix = namePrefix ? `${namePrefix}/${dirName}` : dirName
+        const nestedSkills = await discoverSkillsInDirAsync(
           resolvedPath,
-          dirName,
           scope,
-          namePrefix,
-          depth,
+          nestedPrefix,
+          depth + 1,
+          maxDepth,
         )
-      } catch {
-        // no entrypoint in this directory; recurse if depth allows
+        collected.push(...nestedSkills)
       }
 
-      if (depth >= maxDepth) {
-        return null
-      }
-
-      const nestedPrefix = namePrefix ? `${namePrefix}/${dirName}` : dirName
-      const nestedSkills = await discoverSkillsInDirAsync(
-        resolvedPath,
-        scope,
-        nestedPrefix,
-        depth + 1,
-        maxDepth,
-      )
-
-      return nestedSkills.length > 0 ? nestedSkills : null
+      if (collected.length === 0) return null
+      if (collected.length === 1) return collected[0]
+      return collected
     }
 
     const skillPromises = await mapWithConcurrency(entries, processEntry, 16)

--- a/src/features/opencode-skill-loader/skill-definition-record.test.ts
+++ b/src/features/opencode-skill-loader/skill-definition-record.test.ts
@@ -14,7 +14,7 @@ function makeSkill(partial: Partial<LoadedSkill> & { name: string }): LoadedSkil
   }
 }
 
-describe("skillsToCommandDefinitionRecord — spec-default (hideNestedByDefault: false)", () => {
+describe("skillsToCommandDefinitionRecord - spec-default (hideNestedByDefault: false)", () => {
   it("includes top-level skills by default", () => {
     // given
     const skills: LoadedSkill[] = [
@@ -69,7 +69,7 @@ describe("skillsToCommandDefinitionRecord — spec-default (hideNestedByDefault:
   })
 })
 
-describe("skillsToCommandDefinitionRecord — OmO inversion (hideNestedByDefault: true)", () => {
+describe("skillsToCommandDefinitionRecord - OmO inversion (hideNestedByDefault: true)", () => {
   it("hides nested skills whose user-invocable is unset", () => {
     // given
     const skills: LoadedSkill[] = [
@@ -82,7 +82,7 @@ describe("skillsToCommandDefinitionRecord — OmO inversion (hideNestedByDefault
       hideNestedByDefault: true,
     })
 
-    // then — nested is hidden, top-level unaffected
+    // then - nested is hidden, top-level unaffected
     expect(Object.keys(record).sort()).toEqual(["top-level"])
   })
 
@@ -108,7 +108,7 @@ describe("skillsToCommandDefinitionRecord — OmO inversion (hideNestedByDefault
       hideNestedByDefault: true,
     })
 
-    // then — opted-in nested visible under flat name; other hidden
+    // then - opted-in nested visible under flat name; other hidden
     expect(Object.keys(record).sort()).toEqual(["opted-in", "top-level"])
   })
 
@@ -129,7 +129,7 @@ describe("skillsToCommandDefinitionRecord — OmO inversion (hideNestedByDefault
   })
 })
 
-describe("skillsToCommandDefinitionRecord — collision handling", () => {
+describe("skillsToCommandDefinitionRecord - collision handling", () => {
   it("falls back to prefixed path when two nested skills collide on flat name", () => {
     // given
     const skills: LoadedSkill[] = [
@@ -148,7 +148,7 @@ describe("skillsToCommandDefinitionRecord — collision handling", () => {
     // when
     const record = skillsToCommandDefinitionRecord(skills)
 
-    // then — first wins the flat key, second falls back to prefixed
+    // then - first wins the flat key, second falls back to prefixed
     expect(Object.keys(record).sort()).toEqual([
       "auth-patterns",
       "quality-standard/auth-patterns",
@@ -156,7 +156,7 @@ describe("skillsToCommandDefinitionRecord — collision handling", () => {
   })
 
   it("yields to a top-level skill that owns the same flat name regardless of iteration order", () => {
-    // given — nested appears before top-level in input array
+    // given - nested appears before top-level in input array
     const skills: LoadedSkill[] = [
       makeSkill({
         name: "security/auth-patterns",
@@ -169,7 +169,7 @@ describe("skillsToCommandDefinitionRecord — collision handling", () => {
     // when
     const record = skillsToCommandDefinitionRecord(skills)
 
-    // then — top-level owns flat slot, nested takes prefixed path
+    // then - top-level owns flat slot, nested takes prefixed path
     expect(Object.keys(record).sort()).toEqual([
       "auth-patterns",
       "security/auth-patterns",

--- a/src/features/opencode-skill-loader/types.ts
+++ b/src/features/opencode-skill-loader/types.ts
@@ -56,12 +56,13 @@ export interface LoadedSkill {
    */
   depth?: number
   /**
-   * Resolved visibility in the slash-command picker. Derived at load
-   * time from the Claude Code `user-invocable` frontmatter field (default
-   * true) XOR'd with the OmO `skills.hide_nested_by_default` inversion
-   * flag when the skill is nested. Non-invocable skills remain callable
-   * via the skill tool and load_skills delegation; only the slash menu
-   * is affected.
+   * Raw Claude Code `user-invocable` frontmatter value, if set. Undefined
+   * when the frontmatter field is omitted. The effective slash-command
+   * visibility (which also factors in the spec default of true and the
+   * OmO `skills.hide_nested_by_default` inversion for nested skills) is
+   * computed later during command registration, not stored here. Hidden
+   * skills remain callable via the skill tool and load_skills
+   * delegation; only the slash menu is affected.
    */
   userInvocable?: boolean
   /**

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -1026,20 +1026,19 @@ describe("todo-continuation-enforcer", () => {
   })
 
   test("should show countdown toast updates", async () => {
-    fakeTimers.restore()
     // given - session with incomplete todos
     const sessionID = "main-toast"
     setMainSession(sessionID)
 
     const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
 
-    // when - session goes idle
+    // when - session goes idle, then fake timers advance through the full countdown
     await hook.handler({
       event: { type: "session.idle", properties: { sessionID } },
     })
+    await fakeTimers.advanceBy(2500, true)
 
     // then - multiple toast updates during countdown (2s countdown = 2 toasts: "2s" and "1s")
-    await wait(2500)
     expect(toastCalls.length).toBeGreaterThanOrEqual(2)
     expect(toastCalls[0].message).toContain("2s")
   }, { timeout: 15000 })


### PR DESCRIPTION
## Summary

Addresses review comments from PRs #52, #53, #54, #55 (all already merged) and fixes the flaky `should show countdown toast updates` test that caused intermittent CI failures on PR #54.

### Flaky test fix
- `src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts:1028` called `fakeTimers.restore()` and then used real-timer `wait(2500)`, which could miss a setInterval tick on loaded CI runners. Replaced with `fakeTimers.advanceBy(2500, true)` for deterministic timing.
- Validated with 15 consecutive local runs of the specific test.

### PR #52 corrections (Kilo, Copilot, Codex)
- Latest upstream tag was `v3.17.4`, not `v3.18.0`. Verified via GitHub API.
- `publish.yml` force-resets `master` to the release tag, not a `dev -> master` merge commit. Doc now matches behavior.
- Removed advice to leave `upstream-version.txt` unchanged on skipped releases. The tag watcher reads it every 15 minutes and would spin up repeated analyzer dispatches. Documented the safe alternatives instead.

### PR #53 hardening (Kilo)
- `z.string().min(1)` accepts whitespace-only strings (`" "`, `"\t\n"`) because they are length-1. Replaced with a `NonBlankStringSchema` helper that trims first, rejecting whitespace.
- Added regression tests for `disabled_skills` and `disabled_commands` with whitespace inputs.

### PR #54 correctness + docstring (Copilot)
- `LoadedSkill.userInvocable` docstring claimed the field held a resolved value derived by XOR with `skills.hide_nested_by_default`. The field actually stores the raw frontmatter value unchanged. Rewrote the doc to match.

### PR #54 / #55 cleanup (Devin)
- Removed dead imports `basename` + `isMarkdownFile` from `async-loader.ts` left over from the plain-`.md` removal.
- `discoverSkillsInDirAsync` returned early as soon as it found a SKILL.md entrypoint, while `loadSkillsFromDir` always recurses. Aligned the two paths so the blocking-worker discovery also finds nested skills inside a directory with its own SKILL.md.

### Style (Devin, all PRs)
- Replaced every em dash (U+2014) I introduced across `docs/SYNC_METHODOLOGY.md`, `docs/fork-deviations.md`, `src/features/opencode-skill-loader/async-loader.test.ts`, `src/features/opencode-skill-loader/skill-definition-record.test.ts`, `src/config/schema/oh-my-opencode-config.ts`, and `src/features/opencode-skill-loader/types.ts` with ASCII hyphens per AGENTS.md line 129.

## Not addressed (intentionally deferred)

- `docs/SYNC_METHODOLOGY.md` kebab-case rename (Devin): low-value churn for a merged doc with stable cross-references. Captured for later decision.
- Devin's note about `disabled_commands` only filtering builtin commands: real observation, but a separate concern from the schema change. Filed as future work in NEXT_SESSION_HANDOFF.
- Inconsistent `min(1)` across other `disabled_*` fields: not in scope for this review-feedback PR.

## Test Plan

- `bun run typecheck` - clean
- `bun test src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts --test-name-pattern "should show countdown toast updates"` - 15/15 pass
- `bun run script/run-ci-tests.ts` (the exact script CI runs) - full pass
- `act -j typecheck -W .github/workflows/ci.yml --container-architecture linux/amd64 -P ubuntu-latest=catthehacker/ubuntu:act-latest` - pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky countdown toast test and aligns async skill discovery so nested skills are found. Also tightens config validation and corrects docs and comments.

- **Bug Fixes**
  - Make the countdown toast test deterministic with `fakeTimers.advanceBy(2500, true)` and remove real-timer waits.
  - Async loader now collects a directory’s skill and still recurses into subdirectories; removed dead imports to match the sync path.
  - Reject whitespace-only values in `disabled_skills` and `disabled_commands` via a `NonBlankStringSchema` (with tests).
  - Correct `LoadedSkill.userInvocable` docstring to reflect storing the raw frontmatter value.

- **Docs**
  - Update `docs/SYNC_METHODOLOGY.md`: latest upstream tag is `v3.17.4`, clarify that `publish.yml` force-resets `master` to the release tag, and document safe handling for skipped tags (`upstream-version.txt` advancement or `.upstream-watcher-seen-tag`).
  - Replace em dashes with ASCII hyphens in docs and tests; minor wording fixes in `docs/fork-deviations.md`.

<sup>Written for commit 48ed773087ca7872c5862671d7d68f536fbb9006. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

