### PR TITLE
fix: address remaining PR review feedback from #53, #54, #57

### DIFF
--- a/src/config/schema/agent-names.test.ts
+++ b/src/config/schema/agent-names.test.ts
@@ -135,6 +135,17 @@ describe("OhMyOpenCodeConfigSchema other disabled_* fields parity", () => {
     expect(result.success).toBe(false)
   })
 
+  test("disabled_agents rejects empty strings", () => {
+    // given
+    const config = { disabled_agents: [""] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
   test("disabled_hooks rejects whitespace-only strings", () => {
     // given
     const config = { disabled_hooks: ["\n"] }
@@ -146,9 +157,53 @@ describe("OhMyOpenCodeConfigSchema other disabled_* fields parity", () => {
     expect(result.success).toBe(false)
   })
 
+  test("disabled_hooks rejects empty strings", () => {
+    // given
+    const config = { disabled_hooks: [""] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
   test("disabled_tools rejects whitespace-only strings", () => {
     // given
     const config = { disabled_tools: ["   "] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("disabled_tools rejects empty strings", () => {
+    // given
+    const config = { disabled_tools: [""] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("disabled_mcps rejects whitespace-only strings", () => {
+    // given
+    const config = { disabled_mcps: ["  "] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("disabled_mcps rejects empty strings", () => {
+    // given
+    const config = { disabled_mcps: [""] }
 
     // when
     const result = OhMyOpenCodeConfigSchema.safeParse(config)

--- a/src/config/schema/agent-names.test.ts
+++ b/src/config/schema/agent-names.test.ts
@@ -122,3 +122,52 @@ describe("OhMyOpenCodeConfigSchema disabled_commands", () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe("OhMyOpenCodeConfigSchema other disabled_* fields parity", () => {
+  test("disabled_agents rejects whitespace-only strings", () => {
+    // given
+    const config = { disabled_agents: [" ", "\t"] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("disabled_hooks rejects whitespace-only strings", () => {
+    // given
+    const config = { disabled_hooks: ["\n"] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("disabled_tools rejects whitespace-only strings", () => {
+    // given
+    const config = { disabled_tools: ["   "] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("disabled_agents accepts valid names", () => {
+    // given
+    const config = { disabled_agents: ["my-agent", "another-agent"] }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.disabled_agents).toEqual(["my-agent", "another-agent"])
+    }
+  })
+})

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -1,5 +1,4 @@
 import { z } from "zod"
-import { AnyMcpNameSchema } from "../../mcp/types"
 import { AgentDefinitionsConfigSchema } from "./agent-definitions"
 import { AgentOverridesSchema } from "./agent-overrides"
 import { BabysittingConfigSchema } from "./babysitting"
@@ -36,7 +35,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   default_run_agent: z.string().optional(),
   /** Paths to external agent definition files (.md or .json) */
   agent_definitions: AgentDefinitionsConfigSchema,
-  disabled_mcps: z.array(AnyMcpNameSchema).optional(),
+  disabled_mcps: z.array(NonBlankStringSchema).optional(),
   disabled_agents: z.array(NonBlankStringSchema).optional(),
   /**
    * Skills to hide from discovery. Accepts any skill name, not just builtins.

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -37,7 +37,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   /** Paths to external agent definition files (.md or .json) */
   agent_definitions: AgentDefinitionsConfigSchema,
   disabled_mcps: z.array(AnyMcpNameSchema).optional(),
-  disabled_agents: z.array(z.string()).optional(),
+  disabled_agents: z.array(NonBlankStringSchema).optional(),
   /**
    * Skills to hide from discovery. Accepts any skill name, not just builtins.
    * Matches against the skill's registered name (e.g. "review-work",
@@ -46,14 +46,19 @@ export const OhMyOpenCodeConfigSchema = z.object({
    * strings are rejected so typos surface during config validation.
    */
   disabled_skills: z.array(NonBlankStringSchema).optional(),
-  disabled_hooks: z.array(z.string()).optional(),
+  disabled_hooks: z.array(NonBlankStringSchema).optional(),
   /**
-   * Commands to hide. Accepts any command name, not just builtins. Unknown
-   * names are a silent no-op. Whitespace-only strings are rejected.
+   * Builtin commands to hide from the command picker. Only the OmO builtin
+   * commands (e.g. init-deep, ralph-loop, refactor, start-work) pass through
+   * this filter; user-defined commands loaded from .opencode/commands/ and
+   * skill-sourced commands are always spread on top without consulting this
+   * list. Accepts any string for forward compatibility with new builtin
+   * commands. Unknown names are a silent no-op. Whitespace-only strings are
+   * rejected.
    */
   disabled_commands: z.array(NonBlankStringSchema).optional(),
   /** Disable specific tools by name (e.g., ["todowrite", "todoread"]) */
-  disabled_tools: z.array(z.string()).optional(),
+  disabled_tools: z.array(NonBlankStringSchema).optional(),
   mcp_env_allowlist: z.array(z.string()).optional(),
   /** Enable hashline_edit tool/hook integrations (default: false) */
   hashline_edit: z.boolean().optional(),

--- a/src/features/opencode-skill-loader/async-loader.ts
+++ b/src/features/opencode-skill-loader/async-loader.ts
@@ -173,37 +173,27 @@ export async function discoverSkillsInDirAsync(
       const collected: LoadedSkill[] = []
 
       const skillMdPath = join(resolvedPath, "SKILL.md")
-      try {
-        await readFile(skillMdPath, "utf-8")
-        const loaded = await loadSkillFromPathAsync(
-          skillMdPath,
+      const skillFromSkillMd = await loadSkillFromPathAsync(
+        skillMdPath,
+        resolvedPath,
+        dirName,
+        scope,
+        namePrefix,
+        depth,
+      )
+      if (skillFromSkillMd) {
+        collected.push(skillFromSkillMd)
+      } else {
+        const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
+        const skillFromNamedMd = await loadSkillFromPathAsync(
+          namedSkillMdPath,
           resolvedPath,
           dirName,
           scope,
           namePrefix,
           depth,
         )
-        if (loaded) collected.push(loaded)
-      } catch {
-        // no SKILL.md at this path; try {dirName}.md fallback next
-      }
-
-      if (collected.length === 0) {
-        const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
-        try {
-          await readFile(namedSkillMdPath, "utf-8")
-          const loaded = await loadSkillFromPathAsync(
-            namedSkillMdPath,
-            resolvedPath,
-            dirName,
-            scope,
-            namePrefix,
-            depth,
-          )
-          if (loaded) collected.push(loaded)
-        } catch {
-          // no entrypoint in this directory; rely on recursion below
-        }
+        if (skillFromNamedMd) collected.push(skillFromNamedMd)
       }
 
       if (depth < maxDepth) {

--- a/src/features/opencode-skill-loader/skill-definition-record.test.ts
+++ b/src/features/opencode-skill-loader/skill-definition-record.test.ts
@@ -175,4 +175,60 @@ describe("skillsToCommandDefinitionRecord - collision handling", () => {
       "security/auth-patterns",
     ])
   })
+
+  it("reserves flat-name slot when top-level is hidden via user-invocable false", () => {
+    // given - hidden top-level and a nested skill that would otherwise claim
+    // the same flat name
+    const skills: LoadedSkill[] = [
+      makeSkill({ name: "auth-patterns", userInvocable: false }),
+      makeSkill({
+        name: "security/auth-patterns",
+        depth: 1,
+        flatName: "auth-patterns",
+      }),
+    ]
+
+    // when
+    const record = skillsToCommandDefinitionRecord(skills)
+
+    // then - nested falls back to prefixed path because the hidden
+    // top-level still owns the flat slot; the hidden top-level is not
+    // registered itself
+    expect(Object.keys(record).sort()).toEqual(["security/auth-patterns"])
+  })
+
+  it("shares keyAssignedTo across calls so cross-source collisions resolve", () => {
+    // given - two separate calls (simulating two sources) feed the same
+    // ownership map; first source claims the flat name, second source tries
+    // the same flat name
+    const keyAssignedTo = new Map<string, string>()
+
+    const sourceA: LoadedSkill[] = [
+      makeSkill({
+        name: "quality-standard/qs-anti-patterns",
+        depth: 1,
+        flatName: "qs-anti-patterns",
+      }),
+    ]
+
+    const sourceB: LoadedSkill[] = [
+      makeSkill({
+        name: "other-hub/qs-anti-patterns",
+        depth: 1,
+        flatName: "qs-anti-patterns",
+      }),
+    ]
+
+    // when
+    const recordA = skillsToCommandDefinitionRecord(sourceA, {
+      keyAssignedTo,
+    })
+    const recordB = skillsToCommandDefinitionRecord(sourceB, {
+      keyAssignedTo,
+    })
+
+    // then - source A wins the flat slot, source B falls back to prefixed
+    expect(Object.keys(recordA)).toEqual(["qs-anti-patterns"])
+    expect(Object.keys(recordB)).toEqual(["other-hub/qs-anti-patterns"])
+  })
 })

--- a/src/features/opencode-skill-loader/skill-definition-record.ts
+++ b/src/features/opencode-skill-loader/skill-definition-record.ts
@@ -44,7 +44,9 @@ export function skillsToCommandDefinitionRecord(
 
   for (const skill of topLevel) {
     if (!isVisibleInSlash(skill, false)) {
-      keyAssignedTo.set(skill.name, skill.name)
+      if (!keyAssignedTo.has(skill.name)) {
+        keyAssignedTo.set(skill.name, skill.name)
+      }
       continue
     }
     registerSkill(result, keyAssignedTo, skill.name, skill)

--- a/src/features/opencode-skill-loader/skill-definition-record.ts
+++ b/src/features/opencode-skill-loader/skill-definition-record.ts
@@ -12,6 +12,16 @@ export interface SkillsToCommandDefinitionRecordOptions {
    * affected by this option.
    */
   hideNestedByDefault?: boolean
+  /**
+   * Shared slash-key ownership map used to resolve flat-name collisions
+   * across multiple skill sources (user vs project vs opencode vs
+   * opencode-project). The command-config handler passes a single map
+   * across every skillsToCommandDefinitionRecord call so a nested skill
+   * in one source cannot claim a flat name already owned by a skill in
+   * another source; it falls back to its path-prefixed form instead.
+   * When omitted, each call uses its own map (single-source mode).
+   */
+  keyAssignedTo?: Map<string, string>
 }
 
 export function skillsToCommandDefinitionRecord(
@@ -20,7 +30,7 @@ export function skillsToCommandDefinitionRecord(
 ): Record<string, CommandDefinition> {
   const hideNestedByDefault = options.hideNestedByDefault ?? false
   const result: Record<string, CommandDefinition> = {}
-  const keyAssignedTo = new Map<string, string>()
+  const keyAssignedTo = options.keyAssignedTo ?? new Map<string, string>()
 
   const topLevel: LoadedSkill[] = []
   const nested: LoadedSkill[] = []
@@ -33,7 +43,10 @@ export function skillsToCommandDefinitionRecord(
   }
 
   for (const skill of topLevel) {
-    if (!isVisibleInSlash(skill, false)) continue
+    if (!isVisibleInSlash(skill, false)) {
+      keyAssignedTo.set(skill.name, skill.name)
+      continue
+    }
     registerSkill(result, keyAssignedTo, skill.name, skill)
   }
 

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -238,6 +238,42 @@ describe("parseConfigPartially", () => {
       expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
       expect(result!.disabled_hooks).toEqual(["not-a-real-hook"]);
     });
+
+    it("drops whitespace-only disabled_* entries even on the partial fast path", () => {
+      // given - an otherwise-invalid config that forces the partial fallback
+      // plus whitespace-only entries that would pass the string-array fast
+      // path if we did not explicitly re-check non-blank semantics
+      const rawConfig = {
+        agents: { oracle: { temperature: "not-a-number" } },
+        disabled_skills: ["real-skill", "  "],
+        disabled_commands: ["\t"],
+      };
+
+      // when
+      const result = parseConfigPartially(rawConfig);
+
+      // then
+      expect(result).not.toBeNull();
+      // disabled_skills entire array is rejected because it contains a blank
+      expect(result!.disabled_skills).toBeUndefined();
+      // disabled_commands entire array is rejected for the same reason
+      expect(result!.disabled_commands).toBeUndefined();
+    });
+
+    it("keeps valid disabled_* entries on the partial fast path when no blanks are present", () => {
+      // given
+      const rawConfig = {
+        agents: { oracle: { temperature: "not-a-number" } },
+        disabled_skills: ["real-skill", "another-skill"],
+      };
+
+      // when
+      const result = parseConfigPartially(rawConfig);
+
+      // then
+      expect(result).not.toBeNull();
+      expect(result!.disabled_skills).toEqual(["real-skill", "another-skill"]);
+    });
   });
 
   describe("completely invalid config", () => {

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -45,6 +45,19 @@ const PARTIAL_STRING_ARRAY_KEYS = new Set([
   "agent_definitions",
 ]);
 
+// Keys whose fast-path accepts only non-blank strings. Must stay in sync with
+// the NonBlankStringSchema-validated fields in OhMyOpenCodeConfigSchema; a
+// whitespace-only value here would silently bypass the main schema when a
+// sibling section is invalid and forces the partial fallback.
+const PARTIAL_NON_BLANK_STRING_ARRAY_KEYS = new Set([
+  "disabled_mcps",
+  "disabled_agents",
+  "disabled_skills",
+  "disabled_hooks",
+  "disabled_commands",
+  "disabled_tools",
+]);
+
 export function parseConfigPartially(
   rawConfig: Record<string, unknown>
 ): OhMyOpenCodeConfig | null {
@@ -59,9 +72,18 @@ export function parseConfigPartially(
   for (const key of Object.keys(rawConfig)) {
     if (PARTIAL_STRING_ARRAY_KEYS.has(key)) {
       const sectionValue = rawConfig[key];
-      if (Array.isArray(sectionValue) && sectionValue.every((value) => typeof value === "string")) {
-        partialConfig[key] = sectionValue;
+      if (!Array.isArray(sectionValue)) continue;
+      if (!sectionValue.every((value) => typeof value === "string")) continue;
+      if (
+        PARTIAL_NON_BLANK_STRING_ARRAY_KEYS.has(key) &&
+        sectionValue.some((value) => (value as string).trim().length === 0)
+      ) {
+        invalidSections.push(
+          `${key}: array contains empty or whitespace-only entries`,
+        );
+        continue;
       }
+      partialConfig[key] = sectionValue;
       continue;
     }
 

--- a/src/plugin-handlers/command-config-handler.test.ts
+++ b/src/plugin-handlers/command-config-handler.test.ts
@@ -41,12 +41,12 @@ describe("applyCommandConfig", () => {
   let loadOpencodeGlobalCommandsSpy: ReturnType<typeof spyOn>;
   let loadOpencodeProjectCommandsSpy: ReturnType<typeof spyOn>;
   let discoverConfigSourceSkillsSpy: ReturnType<typeof spyOn>;
-  let loadUserSkillsSpy: ReturnType<typeof spyOn>;
-  let loadProjectSkillsSpy: ReturnType<typeof spyOn>;
-  let loadOpencodeGlobalSkillsSpy: ReturnType<typeof spyOn>;
-  let loadOpencodeProjectSkillsSpy: ReturnType<typeof spyOn>;
-  let loadProjectAgentsSkillsSpy: ReturnType<typeof spyOn>;
-  let loadGlobalAgentsSkillsSpy: ReturnType<typeof spyOn>;
+  let discoverUserClaudeSkillsSpy: ReturnType<typeof spyOn>;
+  let discoverProjectClaudeSkillsSpy: ReturnType<typeof spyOn>;
+  let discoverOpencodeGlobalSkillsSpy: ReturnType<typeof spyOn>;
+  let discoverOpencodeProjectSkillsSpy: ReturnType<typeof spyOn>;
+  let discoverProjectAgentsSkillsSpy: ReturnType<typeof spyOn>;
+  let discoverGlobalAgentsSkillsSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     loadBuiltinCommandsSpy = spyOn(builtinCommands, "loadBuiltinCommands").mockReturnValue({});
@@ -55,12 +55,12 @@ describe("applyCommandConfig", () => {
     loadOpencodeGlobalCommandsSpy = spyOn(commandLoader, "loadOpencodeGlobalCommands").mockResolvedValue({});
     loadOpencodeProjectCommandsSpy = spyOn(commandLoader, "loadOpencodeProjectCommands").mockResolvedValue({});
     discoverConfigSourceSkillsSpy = spyOn(skillLoader, "discoverConfigSourceSkills").mockResolvedValue([]);
-    loadUserSkillsSpy = spyOn(skillLoader, "loadUserSkills").mockResolvedValue({});
-    loadProjectSkillsSpy = spyOn(skillLoader, "loadProjectSkills").mockResolvedValue({});
-    loadOpencodeGlobalSkillsSpy = spyOn(skillLoader, "loadOpencodeGlobalSkills").mockResolvedValue({});
-    loadOpencodeProjectSkillsSpy = spyOn(skillLoader, "loadOpencodeProjectSkills").mockResolvedValue({});
-    loadProjectAgentsSkillsSpy = spyOn(skillLoader, "loadProjectAgentsSkills").mockResolvedValue({});
-    loadGlobalAgentsSkillsSpy = spyOn(skillLoader, "loadGlobalAgentsSkills").mockResolvedValue({});
+    discoverUserClaudeSkillsSpy = spyOn(skillLoader, "discoverUserClaudeSkills").mockResolvedValue([]);
+    discoverProjectClaudeSkillsSpy = spyOn(skillLoader, "discoverProjectClaudeSkills").mockResolvedValue([]);
+    discoverOpencodeGlobalSkillsSpy = spyOn(skillLoader, "discoverOpencodeGlobalSkills").mockResolvedValue([]);
+    discoverOpencodeProjectSkillsSpy = spyOn(skillLoader, "discoverOpencodeProjectSkills").mockResolvedValue([]);
+    discoverProjectAgentsSkillsSpy = spyOn(skillLoader, "discoverProjectAgentsSkills").mockResolvedValue([]);
+    discoverGlobalAgentsSkillsSpy = spyOn(skillLoader, "discoverGlobalAgentsSkills").mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -70,28 +70,40 @@ describe("applyCommandConfig", () => {
     loadOpencodeGlobalCommandsSpy.mockRestore();
     loadOpencodeProjectCommandsSpy.mockRestore();
     discoverConfigSourceSkillsSpy.mockRestore();
-    loadUserSkillsSpy.mockRestore();
-    loadProjectSkillsSpy.mockRestore();
-    loadOpencodeGlobalSkillsSpy.mockRestore();
-    loadOpencodeProjectSkillsSpy.mockRestore();
-    loadProjectAgentsSkillsSpy.mockRestore();
-    loadGlobalAgentsSkillsSpy.mockRestore();
+    discoverUserClaudeSkillsSpy.mockRestore();
+    discoverProjectClaudeSkillsSpy.mockRestore();
+    discoverOpencodeGlobalSkillsSpy.mockRestore();
+    discoverOpencodeProjectSkillsSpy.mockRestore();
+    discoverProjectAgentsSkillsSpy.mockRestore();
+    discoverGlobalAgentsSkillsSpy.mockRestore();
   });
 
   test("includes .agents skills in command config", async () => {
-    // given
-    loadProjectAgentsSkillsSpy.mockResolvedValue({
-      "agents-project-skill": {
-        description: "(project - Skill) Agents project skill",
-        template: "template",
+    // given - mocked LoadedSkill arrays with top-level skills (depth 0)
+    discoverProjectAgentsSkillsSpy.mockResolvedValue([
+      {
+        name: "agents-project-skill",
+        scope: "project",
+        definition: {
+          name: "agents-project-skill",
+          description: "(project - Skill) Agents project skill",
+          template: "template",
+        },
+        depth: 0,
       },
-    });
-    loadGlobalAgentsSkillsSpy.mockResolvedValue({
-      "agents-global-skill": {
-        description: "(user - Skill) Agents global skill",
-        template: "template",
+    ]);
+    discoverGlobalAgentsSkillsSpy.mockResolvedValue([
+      {
+        name: "agents-global-skill",
+        scope: "user",
+        definition: {
+          name: "agents-global-skill",
+          description: "(user - Skill) Agents global skill",
+          template: "template",
+        },
+        depth: 0,
       },
-    });
+    ]);
     const config: Record<string, unknown> = { command: {} };
 
     // when
@@ -128,10 +140,10 @@ describe("applyCommandConfig", () => {
     });
 
     // then
-    expect(loadUserSkillsSpy).toHaveBeenCalledTimes(1);
-    expect(loadProjectSkillsSpy).toHaveBeenCalledTimes(1);
-    expect(loadGlobalAgentsSkillsSpy).not.toHaveBeenCalled();
-    expect(loadProjectAgentsSkillsSpy).not.toHaveBeenCalled();
+    expect(discoverUserClaudeSkillsSpy).toHaveBeenCalledTimes(1);
+    expect(discoverProjectClaudeSkillsSpy).toHaveBeenCalledTimes(1);
+    expect(discoverGlobalAgentsSkillsSpy).not.toHaveBeenCalled();
+    expect(discoverProjectAgentsSkillsSpy).not.toHaveBeenCalled();
   });
 
   test("loads only .agents skills when claude_code.skills.claude is false", async () => {
@@ -154,10 +166,10 @@ describe("applyCommandConfig", () => {
     });
 
     // then
-    expect(loadUserSkillsSpy).not.toHaveBeenCalled();
-    expect(loadProjectSkillsSpy).not.toHaveBeenCalled();
-    expect(loadGlobalAgentsSkillsSpy).toHaveBeenCalledTimes(1);
-    expect(loadProjectAgentsSkillsSpy).toHaveBeenCalledTimes(1);
+    expect(discoverUserClaudeSkillsSpy).not.toHaveBeenCalled();
+    expect(discoverProjectClaudeSkillsSpy).not.toHaveBeenCalled();
+    expect(discoverGlobalAgentsSkillsSpy).toHaveBeenCalledTimes(1);
+    expect(discoverProjectAgentsSkillsSpy).toHaveBeenCalledTimes(1);
   });
 
   test("normalizes Atlas command agents to the runtime list name used by opencode command routing", async () => {

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -12,14 +12,15 @@ import {
 import { loadBuiltinCommands } from "../features/builtin-commands";
 import {
   discoverConfigSourceSkills,
-  loadGlobalAgentsSkills,
-  loadProjectAgentsSkills,
-  loadUserSkills,
-  loadProjectSkills,
-  loadOpencodeGlobalSkills,
-  loadOpencodeProjectSkills,
+  discoverGlobalAgentsSkills,
+  discoverProjectAgentsSkills,
+  discoverUserClaudeSkills,
+  discoverProjectClaudeSkills,
+  discoverOpencodeGlobalSkills,
+  discoverOpencodeProjectSkills,
   skillsToCommandDefinitionRecord,
 } from "../features/opencode-skill-loader";
+import type { LoadedSkill } from "../features/opencode-skill-loader";
 import {
   detectExternalSkillPlugin,
   getSkillPluginConflictWarning,
@@ -50,10 +51,8 @@ export async function applyCommandConfig(params: {
   }
 
   const hideNestedByDefault = resolveHideNestedByDefault(params.pluginConfig.skills);
-  const slashOptions = {
-    hideNestedByDefault,
-    keyAssignedTo: new Map<string, string>(),
-  };
+
+  const emptySkills: LoadedSkill[] = [];
 
   const [
     configSourceSkills,
@@ -76,28 +75,43 @@ export async function applyCommandConfig(params: {
     includeClaudeCommands ? loadProjectCommands(params.ctx.directory) : Promise.resolve({}),
     loadOpencodeGlobalCommands(),
     loadOpencodeProjectCommands(params.ctx.directory),
-    includeClaudeSkills ? loadUserSkills(slashOptions) : Promise.resolve({}),
-    includeAgentsSkills ? loadGlobalAgentsSkills(slashOptions) : Promise.resolve({}),
-    includeClaudeSkills ? loadProjectSkills(params.ctx.directory, slashOptions) : Promise.resolve({}),
-    includeAgentsSkills ? loadProjectAgentsSkills(params.ctx.directory, slashOptions) : Promise.resolve({}),
-    loadOpencodeGlobalSkills(slashOptions),
-    loadOpencodeProjectSkills(params.ctx.directory, slashOptions),
+    includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve(emptySkills),
+    includeAgentsSkills ? discoverGlobalAgentsSkills() : Promise.resolve(emptySkills),
+    includeClaudeSkills ? discoverProjectClaudeSkills(params.ctx.directory) : Promise.resolve(emptySkills),
+    includeAgentsSkills ? discoverProjectAgentsSkills(params.ctx.directory) : Promise.resolve(emptySkills),
+    discoverOpencodeGlobalSkills(),
+    discoverOpencodeProjectSkills(params.ctx.directory),
   ]);
+
+  // Register skill sources sequentially in a deterministic priority order so
+  // flat-name ownership (via the shared keyAssignedTo map) is stable across
+  // runs. The priority order below matches the spread order used to merge
+  // the resulting records onto params.config.command below.
+  const keyAssignedTo = new Map<string, string>();
+  const skillOptions = { hideNestedByDefault, keyAssignedTo };
+
+  const configSourceRecord = skillsToCommandDefinitionRecord(configSourceSkills, skillOptions);
+  const userSkillsRecord = skillsToCommandDefinitionRecord(userSkills, skillOptions);
+  const globalAgentsSkillsRecord = skillsToCommandDefinitionRecord(globalAgentsSkills, skillOptions);
+  const opencodeGlobalSkillsRecord = skillsToCommandDefinitionRecord(opencodeGlobalSkills, skillOptions);
+  const projectSkillsRecord = skillsToCommandDefinitionRecord(projectSkills, skillOptions);
+  const projectAgentsSkillsRecord = skillsToCommandDefinitionRecord(projectAgentsSkills, skillOptions);
+  const opencodeProjectSkillsRecord = skillsToCommandDefinitionRecord(opencodeProjectSkills, skillOptions);
 
   params.config.command = {
     ...builtinCommands,
-    ...skillsToCommandDefinitionRecord(configSourceSkills, slashOptions),
+    ...configSourceRecord,
     ...userCommands,
-    ...userSkills,
-    ...globalAgentsSkills,
+    ...userSkillsRecord,
+    ...globalAgentsSkillsRecord,
     ...opencodeGlobalCommands,
-    ...opencodeGlobalSkills,
+    ...opencodeGlobalSkillsRecord,
     ...systemCommands,
     ...projectCommands,
-    ...projectSkills,
-    ...projectAgentsSkills,
+    ...projectSkillsRecord,
+    ...projectAgentsSkillsRecord,
     ...opencodeProjectCommands,
-    ...opencodeProjectSkills,
+    ...opencodeProjectSkillsRecord,
     ...params.pluginComponents.commands,
     ...params.pluginComponents.skills,
   };

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -50,7 +50,10 @@ export async function applyCommandConfig(params: {
   }
 
   const hideNestedByDefault = resolveHideNestedByDefault(params.pluginConfig.skills);
-  const slashOptions = { hideNestedByDefault };
+  const slashOptions = {
+    hideNestedByDefault,
+    keyAssignedTo: new Map<string, string>(),
+  };
 
   const [
     configSourceSkills,


### PR DESCRIPTION
## Summary

Follow-up to PR #57 that resolves the remaining actionable review comments flagged by the bots across PRs #53, #54, and #57 (which itself ran into one new Copilot finding).

### PR #57 Copilot: duplicate readFile in async-loader
`discoverSkillsInDirAsync` did a full `readFile(path, "utf-8")` solely as an existence check and then immediately called `loadSkillFromPathAsync` which reads the same file again internally. Removed the existence check and treat `loadSkillFromPathAsync`'s `null` return as "not a valid skill entrypoint." Two full file reads per directory halved to one.

### PR #54 Codex P2: flat-name collisions across skill sources
Each skill source previously called `skillsToCommandDefinitionRecord` with its own fresh `keyAssignedTo` map. Two nested skills with the same `flatName` in different sources both claimed the flat slot, and the last-spread won silently.

Added an optional shared `keyAssignedTo` map to `SkillsToCommandDefinitionRecordOptions`. `command-config-handler.ts` allocates one map and threads it through all seven skill-source calls so flat-name ownership is global across the whole registration pass. The first source to claim a flat name wins; subsequent collisions fall back to their path-prefixed unique names (consistent with the existing collision policy).

### PR #54 Devin: hidden top-level doesn't reserve slash-key slot
When a top-level skill declared `user-invocable: false` it was skipped entirely and never recorded in `keyAssignedTo`. A nested skill with a matching `flatName` could then claim the slot, so the user's explicit "do not expose this as `/auth-patterns`" leaked through a nested skill that happened to share the basename.

Hidden top-levels now reserve their name in `keyAssignedTo` even though they aren't registered as slash commands, so nested skills detect the reservation and fall back to their path-prefixed name.

### PR #53 Devin: `disabled_commands` JSDoc was misleading
The comment said "Commands to hide. Accepts any command name" but only `loadBuiltinCommands()` consults `disabled_commands` at runtime. User-defined commands from `.opencode/commands/` and skill-sourced commands are loaded independently. Updated the JSDoc to state explicitly that only OmO builtin commands pass through this filter.

### PR #53 Devin: `min(1)` inconsistency across `disabled_*` fields
PR #53 tightened `disabled_skills` and `disabled_commands` to reject whitespace-only strings but left `disabled_agents`, `disabled_hooks`, and `disabled_tools` on plain `z.array(z.string())`. Applied the same `NonBlankStringSchema` to all four so typos surface uniformly. `disabled_mcps` stays as-is because `AnyMcpNameSchema` already enforces `min(1)`.

### New regression tests
- `reserves flat-name slot when top-level is hidden via user-invocable false`
- `shares keyAssignedTo across calls so cross-source collisions resolve`
- `disabled_agents / disabled_hooks / disabled_tools rejects whitespace-only strings`
- `disabled_agents accepts valid names`

## Not addressed (intentionally deferred)

- `SYNC_METHODOLOGY.md` kebab-case rename (PR #52 Devin): low-value churn on a stable, cross-referenced doc.
- `registerSkill` overwrite-on-conflict policy (PR #54 Devin): Devin itself noted this is intentional; left unchanged.
- AI-filler rule-definition false positive (PR #52 Devin): self-clarified as non-issue.
- Arrows `->` not being em dashes (PR #52 Devin): self-clarified as non-issue.
- Orphaned `BuiltinCommandName` / `BuiltinSkillName` schemas (PR #53 Kilo): Devin confirmed still useful as internal type definitions.

## Test Plan

- `bun run typecheck` - clean
- `bun test src/features/opencode-skill-loader/ src/config/schema/agent-names.test.ts src/plugin-handlers/command-config-handler.test.ts` - 132 pass
- `bun run script/run-ci-tests.ts` (exact script CI runs) - 4774 pass, 0 fail
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nondeterministic slash-key assignment and remaining review feedback: resolves flat-name collisions across sources (including hidden top-levels), tightens `disabled_*` validation (now including `disabled_mcps`), speeds up skill discovery by dropping duplicate file reads, and blocks blank `disabled_*` entries during partial config parsing.

- **Bug Fixes**
  - Deterministic collision handling: share a `keyAssignedTo` map and register sources sequentially; hidden top-levels reserve their flat name without overwriting an existing claim; collisions fall back to path-prefixed names.
  - Applied `NonBlankStringSchema` to `disabled_agents`, `disabled_hooks`, `disabled_tools`, and `disabled_mcps`; whitespace-only entries now fail.
  - Partial config fallback: reject blank or whitespace-only values in `disabled_*` arrays on the fast path to match the main schema.
  - Clarified `disabled_commands` JSDoc: only OmO builtin commands are filtered.
  - Added regression tests for sequential registration, slot reservation, new validation cases, and partial-fallback behavior.

- **Refactors**
  - Removed redundant existence-check reads in `discoverSkillsInDirAsync`; call `loadSkillFromPathAsync` directly.

<sup>Written for commit c995845911c6123cb6f8dce852abb084ad36d9bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

