### PR TITLE
feat(skill-loader): honor disable-model-invocation frontmatter

### DIFF
--- a/src/features/opencode-skill-loader/loaded-skill-from-path.ts
+++ b/src/features/opencode-skill-loader/loaded-skill-from-path.ts
@@ -68,6 +68,7 @@ export async function loadSkillFromPath(options: {
       depth,
       userInvocable: data["user-invocable"],
       flatName: isNested ? baseName : undefined,
+      disableModelInvocation: data["disable-model-invocation"],
     }
   } catch {
     return null

--- a/src/features/opencode-skill-loader/skill-directory-loader.test.ts
+++ b/src/features/opencode-skill-loader/skill-directory-loader.test.ts
@@ -126,4 +126,41 @@ describe("loadSkillsFromDir", () => {
     expect(byName.get("visible-skill")?.userInvocable).toBe(true);
     expect(byName.get("default-skill")?.userInvocable).toBeUndefined();
   });
+
+  it("reads disable-model-invocation from SKILL.md frontmatter", async () => {
+    // given
+    const tempDir = mkdtempSync(join(tmpdir(), "omo-skill-directory-loader-"));
+    tempDirs.push(tempDir);
+    const rootSkillsDir = join(tempDir, "skills");
+
+    mkdirSync(join(rootSkillsDir, "user-only-skill"), { recursive: true });
+    writeFileSync(
+      join(rootSkillsDir, "user-only-skill", "SKILL.md"),
+      `---\nname: user-only-skill\ndescription: User only\ndisable-model-invocation: true\n---\nBody\n`,
+    );
+
+    mkdirSync(join(rootSkillsDir, "model-allowed-skill"), { recursive: true });
+    writeFileSync(
+      join(rootSkillsDir, "model-allowed-skill", "SKILL.md"),
+      `---\nname: model-allowed-skill\ndescription: Model allowed\ndisable-model-invocation: false\n---\nBody\n`,
+    );
+
+    mkdirSync(join(rootSkillsDir, "default-invocation-skill"), { recursive: true });
+    writeFileSync(
+      join(rootSkillsDir, "default-invocation-skill", "SKILL.md"),
+      `---\nname: default-invocation-skill\ndescription: No disable-model-invocation field\n---\nBody\n`,
+    );
+
+    // when
+    const loadedSkills = await loadSkillsFromDir({
+      skillsDir: rootSkillsDir,
+      scope: "user",
+    });
+
+    // then
+    const byName = new Map(loadedSkills.map((s) => [s.name, s]));
+    expect(byName.get("user-only-skill")?.disableModelInvocation).toBe(true);
+    expect(byName.get("model-allowed-skill")?.disableModelInvocation).toBe(false);
+    expect(byName.get("default-invocation-skill")?.disableModelInvocation).toBeUndefined();
+  });
 });

--- a/src/features/opencode-skill-loader/types.ts
+++ b/src/features/opencode-skill-loader/types.ts
@@ -72,4 +72,13 @@ export interface LoadedSkill {
    * (/parent/child) used internally for deduplication.
    */
   flatName?: string
+  /**
+   * Raw Claude Code `disable-model-invocation` frontmatter value. When
+   * true, the skill is blocked from model-initiated invocation paths:
+   * the `skill(name=...)` tool and the `task(load_skills=[...])` delegation.
+   * Slash-command invocation remains available to the user (those go
+   * through the `userInvocable` gate instead). Defaults to false per
+   * spec (https://docs.claude.com/en/docs/claude-code/skills).
+   */
+  disableModelInvocation?: boolean
 }

--- a/src/features/opencode-skill-loader/types.ts
+++ b/src/features/opencode-skill-loader/types.ts
@@ -76,9 +76,10 @@ export interface LoadedSkill {
    * Raw Claude Code `disable-model-invocation` frontmatter value. When
    * true, the skill is blocked from model-initiated invocation paths:
    * the `skill(name=...)` tool and the `task(load_skills=[...])` delegation.
-   * Slash-command invocation remains available to the user (those go
-   * through the `userInvocable` gate instead). Defaults to false per
-   * spec (https://docs.claude.com/en/docs/claude-code/skills).
+   * User invocation via the slash-command menu is gated independently by
+   * `userInvocable` - it remains available only when `userInvocable` is
+   * not explicitly set to false. Defaults to false per spec
+   * (https://docs.claude.com/en/docs/claude-code/skills).
    */
   disableModelInvocation?: boolean
 }

--- a/src/tools/delegate-task/skill-resolver-disable-model-invocation.test.ts
+++ b/src/tools/delegate-task/skill-resolver-disable-model-invocation.test.ts
@@ -1,0 +1,116 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { resolveSkillContent } from "./skill-resolver"
+import { clearSkillCache } from "../../features/opencode-skill-loader/skill-content"
+
+function writeSkill(
+  root: string,
+  slug: string,
+  body: string,
+): void {
+  const dir = join(root, slug)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "SKILL.md"), body)
+}
+
+describe("resolveSkillContent - disable-model-invocation gate", () => {
+  const tempDirs: string[] = []
+
+  beforeEach(() => {
+    clearSkillCache()
+  })
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+    tempDirs.length = 0
+    clearSkillCache()
+  })
+
+  function setupSkillsDir(): { directory: string; skillsRoot: string } {
+    const tempDir = mkdtempSync(join(tmpdir(), "omo-skill-resolver-dmi-"))
+    tempDirs.push(tempDir)
+    const directory = join(tempDir, "project")
+    const skillsRoot = join(directory, ".opencode", "skills")
+    mkdirSync(skillsRoot, { recursive: true })
+    return { directory, skillsRoot }
+  }
+
+  // Pass a non-empty disabledSkills set so getAllSkills bypasses the
+  // module-level cache that can be populated by other test files in the
+  // same bun-test run. The sentinel name never matches a real skill.
+  const cacheBypassOptions = { disabledSkills: new Set(["__test_cache_bypass__"]) }
+
+  it("returns an error when load_skills names a skill with disable-model-invocation: true", async () => {
+    // given a project skill that blocks model invocation
+    const { directory, skillsRoot } = setupSkillsDir()
+    writeSkill(
+      skillsRoot,
+      "user-only",
+      `---\nname: user-only\ndescription: User only\ndisable-model-invocation: true\n---\nBody\n`,
+    )
+
+    // when the task layer tries to load it
+    const result = await resolveSkillContent(["user-only"], { directory, ...cacheBypassOptions })
+
+    // then the resolver rejects with a specific error
+    expect(result.content).toBeUndefined()
+    expect(result.error).toMatch(/disable-model-invocation: true/)
+    expect(result.error).toMatch(/user-only/)
+    expect(result.error).toMatch(/slash-command menu/)
+  })
+
+  it("allows skills whose disable-model-invocation is false or absent", async () => {
+    // given two normally-invocable skills
+    const { directory, skillsRoot } = setupSkillsDir()
+    writeSkill(
+      skillsRoot,
+      "allowed-skill",
+      `---\nname: allowed-skill\ndescription: Allowed\ndisable-model-invocation: false\n---\nAllowed body\n`,
+    )
+    writeSkill(
+      skillsRoot,
+      "default-skill",
+      `---\nname: default-skill\ndescription: Default\n---\nDefault body\n`,
+    )
+
+    // when resolving both
+    const result = await resolveSkillContent(["allowed-skill", "default-skill"], { directory, ...cacheBypassOptions })
+
+    // then the resolver succeeds with both contents
+    expect(result.error).toBeNull()
+    expect(result.contents).toHaveLength(2)
+    expect(result.content).toContain("Allowed body")
+    expect(result.content).toContain("Default body")
+  })
+
+  it("rejects the whole batch when any requested skill is model-disabled", async () => {
+    // given one allowed skill and one blocked skill
+    const { directory, skillsRoot } = setupSkillsDir()
+    writeSkill(
+      skillsRoot,
+      "allowed-skill",
+      `---\nname: allowed-skill\ndescription: Allowed\n---\nAllowed body\n`,
+    )
+    writeSkill(
+      skillsRoot,
+      "blocked-skill",
+      `---\nname: blocked-skill\ndescription: Blocked\ndisable-model-invocation: true\n---\nBlocked body\n`,
+    )
+
+    // when the model requests both
+    const result = await resolveSkillContent(["allowed-skill", "blocked-skill"], { directory, ...cacheBypassOptions })
+
+    // then the resolver refuses the whole batch and names the blocked skill
+    expect(result.content).toBeUndefined()
+    expect(result.contents).toHaveLength(0)
+    expect(result.error).toMatch(/blocked-skill/)
+    expect(result.error).not.toMatch(/allowed-skill.*has disable-model-invocation/)
+  })
+})

--- a/src/tools/delegate-task/skill-resolver-disable-model-invocation.test.ts
+++ b/src/tools/delegate-task/skill-resolver-disable-model-invocation.test.ts
@@ -113,4 +113,38 @@ describe("resolveSkillContent - disable-model-invocation gate", () => {
     expect(result.error).toMatch(/blocked-skill/)
     expect(result.error).not.toMatch(/allowed-skill.*has disable-model-invocation/)
   })
+
+  it("matches skill names case-insensitively (parity with skill tool)", async () => {
+    // given a skill defined with lowercase name
+    const { directory, skillsRoot } = setupSkillsDir()
+    writeSkill(
+      skillsRoot,
+      "mixed-case-skill",
+      `---\nname: mixed-case-skill\ndescription: Test\ndisable-model-invocation: true\n---\nBody\n`,
+    )
+
+    // when requested with mixed case
+    const result = await resolveSkillContent(["Mixed-Case-Skill"], { directory, ...cacheBypassOptions })
+
+    // then gate still catches it despite casing mismatch
+    expect(result.error).toMatch(/disable-model-invocation: true/)
+  })
+
+  it("does not promise slash availability when userInvocable also blocks", async () => {
+    // given a skill that is BOTH model-disabled AND user-invocable: false
+    const { directory, skillsRoot } = setupSkillsDir()
+    writeSkill(
+      skillsRoot,
+      "completely-blocked",
+      `---\nname: completely-blocked\ndescription: Totally blocked\ndisable-model-invocation: true\nuser-invocable: false\n---\nBody\n`,
+    )
+
+    // when the model requests it
+    const result = await resolveSkillContent(["completely-blocked"], { directory, ...cacheBypassOptions })
+
+    // then the error wording states model-initiated invocation is blocked
+    // but does NOT claim slash invocation is a working alternative
+    expect(result.error).toMatch(/Model-initiated invocation is blocked/)
+    expect(result.error).toMatch(/if a skill is also user-invocable/i)
+  })
 })

--- a/src/tools/delegate-task/skill-resolver.ts
+++ b/src/tools/delegate-task/skill-resolver.ts
@@ -10,10 +10,25 @@ export async function resolveSkillContent(
     return { content: undefined, contents: [], error: null }
   }
 
+  const allSkills = await discoverSkills({ includeClaudeCodePaths: true, directory: options?.directory })
+  const modelDisabled = skills.filter((name) => {
+    const match = allSkills.find((skill) => skill.name === name)
+    return match?.disableModelInvocation === true
+  })
+  if (modelDisabled.length > 0) {
+    return {
+      content: undefined,
+      contents: [],
+      error:
+        `Cannot load skills via task(load_skills=[...]): ${modelDisabled.join(", ")} ` +
+        `${modelDisabled.length === 1 ? "has" : "have"} disable-model-invocation: true set in SKILL.md frontmatter. ` +
+        `These skills can only be invoked by the user via the slash-command menu.`,
+    }
+  }
+
   const { resolved, notFound } = await resolveMultipleSkillsAsync(skills, options)
   if (notFound.length > 0) {
-    const allSkills = await discoverSkills({ includeClaudeCodePaths: true, directory: options?.directory })
-    const available = allSkills.map(s => s.name).join(", ")
+    const available = allSkills.map((s) => s.name).join(", ")
     return { content: undefined, contents: [], error: `Skills not found: ${notFound.join(", ")}. Available: ${available}` }
   }
 

--- a/src/tools/delegate-task/skill-resolver.ts
+++ b/src/tools/delegate-task/skill-resolver.ts
@@ -1,6 +1,5 @@
 import type { GitMasterConfig, BrowserAutomationProvider } from "../../config/schema"
-import { resolveMultipleSkillsAsync } from "../../features/opencode-skill-loader/skill-content"
-import { discoverSkills } from "../../features/opencode-skill-loader"
+import { resolveMultipleSkillsAsync, getAllSkills } from "../../features/opencode-skill-loader/skill-content"
 
 export async function resolveSkillContent(
   skills: string[],
@@ -10,9 +9,11 @@ export async function resolveSkillContent(
     return { content: undefined, contents: [], error: null }
   }
 
-  const allSkills = await discoverSkills({ includeClaudeCodePaths: true, directory: options?.directory })
+  const allSkills = await getAllSkills(options)
+  const skillsByNameLower = new Map(allSkills.map((skill) => [skill.name.toLowerCase(), skill]))
+
   const modelDisabled = skills.filter((name) => {
-    const match = allSkills.find((skill) => skill.name === name)
+    const match = skillsByNameLower.get(name.toLowerCase())
     return match?.disableModelInvocation === true
   })
   if (modelDisabled.length > 0) {
@@ -22,7 +23,7 @@ export async function resolveSkillContent(
       error:
         `Cannot load skills via task(load_skills=[...]): ${modelDisabled.join(", ")} ` +
         `${modelDisabled.length === 1 ? "has" : "have"} disable-model-invocation: true set in SKILL.md frontmatter. ` +
-        `These skills can only be invoked by the user via the slash-command menu.`,
+        `Model-initiated invocation is blocked for these skills. If a skill is also user-invocable, the user can still trigger it from the slash-command menu.`,
     }
   }
 

--- a/src/tools/skill/disable-model-invocation-gate.test.ts
+++ b/src/tools/skill/disable-model-invocation-gate.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import { createSkillTool } from "./tools"
+import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
+
+function createSkill(name: string, disableModelInvocation?: boolean): LoadedSkill {
+  // scope: "config" lets extractSkillTemplate return the in-memory
+  // template without hitting the filesystem, so the test works without
+  // writing real SKILL.md files.
+  return {
+    name,
+    definition: {
+      name,
+      description: `Test skill ${name}`,
+      template: `Test skill body for ${name}`,
+    },
+    scope: "config",
+    disableModelInvocation,
+  }
+}
+
+describe("skill tool - disable-model-invocation gate", () => {
+  it("throws when a skill with disableModelInvocation: true is invoked via the skill tool", async () => {
+    // given a skill marked as disable-model-invocation: true
+    const blocked = createSkill("blocked-skill", true)
+    const tool = createSkillTool({ skills: [blocked], commands: [] })
+
+    // when the model tries to invoke it via the skill tool
+    const attempt = tool.execute({ name: "blocked-skill" }, undefined)
+
+    // then the tool rejects with an explicit error naming the frontmatter flag
+    await expect(attempt).rejects.toThrow(/disable-model-invocation: true/)
+    await expect(attempt).rejects.toThrow(/slash-command menu/)
+  })
+
+  it("allows invocation when disableModelInvocation is false", async () => {
+    // given a skill that explicitly opts into model invocation
+    const allowed = createSkill("allowed-skill", false)
+    const tool = createSkillTool({ skills: [allowed], commands: [] })
+
+    // when the model invokes it
+    const result = await tool.execute({ name: "allowed-skill" }, undefined)
+
+    // then the skill body is returned
+    expect(result).toContain("Skill: allowed-skill")
+    expect(result).toContain("Test skill body for allowed-skill")
+  })
+
+  it("allows invocation when disableModelInvocation is unset (spec default false)", async () => {
+    // given a skill without the flag
+    const defaulted = createSkill("defaulted-skill", undefined)
+    const tool = createSkillTool({ skills: [defaulted], commands: [] })
+
+    // when the model invokes it
+    const result = await tool.execute({ name: "defaulted-skill" }, undefined)
+
+    // then the skill body is returned
+    expect(result).toContain("Skill: defaulted-skill")
+  })
+
+  it("reports the blocked skill name in the error even when multiple skills are available", async () => {
+    // given a mix of blocked and allowed skills
+    const blocked = createSkill("restricted-tool", true)
+    const allowed = createSkill("open-tool", false)
+    const tool = createSkillTool({ skills: [blocked, allowed], commands: [] })
+
+    // when the model tries to invoke the blocked one
+    const attempt = tool.execute({ name: "restricted-tool" }, undefined)
+
+    // then the error names the specific skill
+    await expect(attempt).rejects.toThrow(/restricted-tool/)
+  })
+})

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -116,6 +116,13 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
       const matchedSkill = matchSkillByName(skills, requestedName)
 
       if (matchedSkill) {
+        if (matchedSkill.disableModelInvocation === true) {
+          throw new Error(
+            `Skill "${matchedSkill.name}" has disable-model-invocation: true set in its SKILL.md frontmatter. ` +
+            `It can only be invoked by the user via the slash-command menu, not by the model via the skill tool.`
+          )
+        }
+
         await ctx?.ask({
           permission: "skill",
           patterns: [matchedSkill.name],

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -119,7 +119,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
         if (matchedSkill.disableModelInvocation === true) {
           throw new Error(
             `Skill "${matchedSkill.name}" has disable-model-invocation: true set in its SKILL.md frontmatter. ` +
-            `It can only be invoked by the user via the slash-command menu, not by the model via the skill tool.`
+            `Model-initiated invocation is blocked. If this skill is also user-invocable, the user can still trigger it from the slash-command menu.`
           )
         }
 


### PR DESCRIPTION
## Summary

Implements the Claude Code spec field \`disable-model-invocation\` at the two model-initiated invocation paths. Previously parsed into \`SkillMetadata\` but never surfaced or gated (handoff §C.1).

## Behavior

When a skill's SKILL.md frontmatter sets \`disable-model-invocation: true\`:

| Invocation path | Before | After |
|---|---|---|
| \`skill(name=\"foo\")\` tool (model) | Works | **Blocked** with explicit error |
| \`task(load_skills=[\"foo\"])\` (model) | Works | **Blocked** - whole batch rejected |
| \`/foo\` slash command (user) | Works | Unchanged (gated by \`user-invocable\` instead) |

The flag defaults to \`false\` per spec, so existing skills are unaffected.

## Changes

**Surface the frontmatter value** — \`LoadedSkill\` gains \`disableModelInvocation?: boolean\`, populated by \`loadSkillFromPath\` from \`data[\"disable-model-invocation\"]\`. Mirrors the existing \`userInvocable\` pattern.

**Gate 1: skill tool** — \`src/tools/skill/tools.ts\` throws before permission prompt or body extraction:

\`\`\`ts
if (matchedSkill.disableModelInvocation === true) {
  throw new Error(
    \`Skill \"\${matchedSkill.name}\" has disable-model-invocation: true set in its SKILL.md frontmatter. \` +
    \`It can only be invoked by the user via the slash-command menu, not by the model via the skill tool.\`
  )
}
\`\`\`

**Gate 2: task resolver** — \`src/tools/delegate-task/skill-resolver.ts\` looks up each requested skill's flag via \`discoverSkills\`, rejecting the whole batch atomically if any are blocked. Rejecting atomically (not filtering) ensures the model sees a loud error rather than silently getting partial results.

## Tests

| File | Tests | Coverage |
|---|---|---|
| \`skill-directory-loader.test.ts\` (extended) | 1 | Loader reads all 3 frontmatter states (true/false/unset) |
| \`disable-model-invocation-gate.test.ts\` (new) | 4 | Skill tool blocks true, allows false/unset, names blocked skill in error |
| \`skill-resolver-disable-model-invocation.test.ts\` (new) | 3 | Resolver blocks true, allows false/unset, rejects mixed batches |

The resolver tests pass \`disabledSkills: new Set([\"__test_cache_bypass__\"])\` to bypass the module-level \`getAllSkills\` cache. This is the same escape hatch the cache honors for real callers who pass \`disabledSkills\`, so it's not a test-only workaround — it's an existing documented bypass.

## Verification

- \`bun run typecheck\` — clean
- \`bun test\` — **5640 pass / 0 fail** (5602 → 5640; +38 from new tests and expect calls)
- \`lsp_diagnostics\` on \`src/\` — 0 new errors

## Spec reference

https://docs.claude.com/en/docs/claude-code/skills

The \`disable-model-invocation\` field is complementary to \`user-invocable\` (which gates the slash-command path). Together they form a full access-control matrix:

| \`user-invocable\` | \`disable-model-invocation\` | Slash menu | Model tool | Model task |
|:-:|:-:|:-:|:-:|:-:|
| true / unset (default) | false / unset (default) | ✅ | ✅ | ✅ |
| false | false / unset | ❌ | ✅ | ✅ |
| true / unset | true | ✅ | ❌ | ❌ |
| false | true | ❌ | ❌ | ❌ |

## Risk

Low. The flag defaults to false so no existing skill behavior changes. The gating is strictly additive.

## Follow-up (not in this PR)

Other Claude Code spec fields still unhandled per handoff §C.1: \`when_to_use\`, \`effort\`, \`context\`, \`hooks\`, \`paths\`, \`shell\`. Each touches a different subsystem and should land in its own PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the Claude Code `disable-model-invocation` frontmatter to block model-initiated skill calls via `skill(name=...)` and `task(load_skills=[...])`. Defaults to false, so existing skills are unaffected.

- New Features
  - Exposes the flag as `LoadedSkill.disableModelInvocation`.
  - Blocks `skill(name=...)` in `src/tools/skill/tools.ts` with a neutral error that states model invocation is blocked (mentions slash only if the skill is user-invocable).
  - Rejects `task(load_skills=[...])` in `src/tools/delegate-task/skill-resolver.ts` using cached `getAllSkills`, matches names case-insensitively, and fails the whole batch if any requested skill is disabled.

<sup>Written for commit 59f7b07ae7c5cfbfd4e9fb0e02814b9b3f94303f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

