### PR TITLE
feat(subagent): opt-in recursion via experimental.subagent_recursion

### DIFF
--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -1,6 +1,21 @@
 import { z } from "zod"
 import { DynamicContextPruningConfigSchema } from "./dynamic-context-pruning"
 
+export const SubagentRecursionConfigSchema = z.object({
+  /**
+   * Gate for the entire feature. When false or absent, subagent recursion
+   * is blocked exactly as before - no behavior change from the default.
+   */
+  enabled: z.boolean().optional(),
+  /**
+   * Agents allowed to spawn subagents when `enabled` is true. Only names
+   * listed here get `call_omo_agent: false` removed from their denylist.
+   * Defaults to `["explore", "librarian"]` when omitted. Oracle is NOT
+   * in the default list because Oracle is meant to be a leaf consultant.
+   */
+  allowed_agents: z.array(z.string()).optional(),
+})
+
 export const ExperimentalConfigSchema = z.object({
   aggressive_truncation: z.boolean().optional(),
   auto_resume: z.boolean().optional(),
@@ -22,6 +37,15 @@ export const ExperimentalConfigSchema = z.object({
   model_fallback_title: z.boolean().optional(),
   /** Maximum number of tools to register. When set, lower-priority tools are excluded to stay within provider limits (e.g., OpenAI's 128-tool cap). Accounts for ~20 OpenCode built-in tools. */
   max_tools: z.number().int().min(1).optional(),
+  /**
+   * Opt-in subagent recursion. When enabled, listed agents can use
+   * `call_omo_agent` to spawn further subagents, capped by the existing
+   * `background_task.maxDepth` (default 3) and `background_task.maxDescendants`
+   * (default 50) guardrails. The `task` tool remains blocked for subagents
+   * even when this flag is on, because `task` bypasses the OmO budget system.
+   */
+  subagent_recursion: SubagentRecursionConfigSchema.optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>
+export type SubagentRecursionConfig = z.infer<typeof SubagentRecursionConfigSchema>

--- a/src/create-managers.ts
+++ b/src/create-managers.ts
@@ -69,6 +69,7 @@ export function createManagers(args: {
     pluginConfig.background_task,
     {
       tmuxConfig,
+      subagentRecursionConfig: pluginConfig.experimental?.subagent_recursion,
       onSubagentSessionCreated: async (event: SubagentSessionCreatedEvent) => {
         log("[create-managers] onSubagentSessionCreated callback received", {
           sessionID: event.sessionID,

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -9,7 +9,7 @@ import type {
 import { TaskHistory } from "./task-history"
 import {
   log,
-  getAgentToolRestrictions,
+  getAgentToolRestrictionsForSpawn,
   normalizePromptTools,
   normalizeSDKResponse,
   promptWithModelSuggestionRetry,
@@ -21,6 +21,7 @@ import { setSessionTools } from "../../shared/session-tools-store"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { ConcurrencyManager } from "./concurrency"
 import type { BackgroundTaskConfig, TmuxConfig } from "../../config/schema"
+import type { SubagentRecursionConfig } from "../../config/schema/experimental"
 import { isInsideTmux } from "../../shared/tmux"
 import {
   shouldRetryError,
@@ -150,6 +151,7 @@ export class BackgroundManager {
   private concurrencyManager: ConcurrencyManager
   private shutdownTriggered = false
   private config?: BackgroundTaskConfig
+  private subagentRecursionConfig?: SubagentRecursionConfig
   private tmuxEnabled: boolean
   private onSubagentSessionCreated?: OnSubagentSessionCreated
   private onShutdown?: () => void | Promise<void>
@@ -176,6 +178,7 @@ export class BackgroundManager {
       onSubagentSessionCreated?: OnSubagentSessionCreated
       onShutdown?: () => void | Promise<void>
       enableParentSessionNotifications?: boolean
+      subagentRecursionConfig?: SubagentRecursionConfig
     }
   ) {
     this.tasks = new Map()
@@ -186,6 +189,7 @@ export class BackgroundManager {
     this.directory = ctx.directory
     this.concurrencyManager = new ConcurrencyManager(config)
     this.config = config
+    this.subagentRecursionConfig = options?.subagentRecursionConfig
     this.tmuxEnabled = options?.tmuxConfig?.enabled ?? false
     this.onSubagentSessionCreated = options?.onSubagentSessionCreated
     this.onShutdown = options?.onShutdown
@@ -577,7 +581,7 @@ export class BackgroundManager {
           task: false,
           call_omo_agent: true,
           question: false,
-          ...getAgentToolRestrictions(input.agent),
+          ...getAgentToolRestrictionsForSpawn(input.agent, this.subagentRecursionConfig),
         }
         setSessionTools(sessionID, tools)
         return tools
@@ -886,7 +890,7 @@ export class BackgroundManager {
             task: false,
             call_omo_agent: true,
             question: false,
-            ...getAgentToolRestrictions(existingTask.agent),
+            ...getAgentToolRestrictionsForSpawn(existingTask.agent, this.subagentRecursionConfig),
           }
           setSessionTools(existingTask.sessionID!, tools)
           return tools

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -170,6 +170,7 @@ export function createToolRegistry(args: {
     pluginConfig.disabled_agents ?? [],
     pluginConfig.agents,
     pluginConfig.categories,
+    pluginConfig.experimental?.subagent_recursion,
   )
 
   const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(
@@ -191,6 +192,7 @@ export function createToolRegistry(args: {
     availableSkills: skillContext.availableSkills,
     sisyphusAgentConfig: pluginConfig.sisyphus_agent,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
+    subagentRecursionConfig: pluginConfig.experimental?.subagent_recursion,
     onSyncSessionCreated: async (event) => {
       log("[index] onSyncSessionCreated callback", {
         sessionID: event.sessionID,

--- a/src/shared/agent-tool-restrictions.test.ts
+++ b/src/shared/agent-tool-restrictions.test.ts
@@ -90,6 +90,16 @@ describe("isSubagentRecursionAllowed", () => {
     expect(isSubagentRecursionAllowed("\u200Bexplore", config)).toBe(true)
   })
 
+  it("normalizes invisibles and whitespace in allowed_agents entries", () => {
+    const config: SubagentRecursionConfig = {
+      enabled: true,
+      allowed_agents: ["\u200BExplore ", " \u200Boracle\u200B"],
+    }
+    expect(isSubagentRecursionAllowed("explore", config)).toBe(true)
+    expect(isSubagentRecursionAllowed("oracle", config)).toBe(true)
+    expect(isSubagentRecursionAllowed("librarian", config)).toBe(false)
+  })
+
   it("empty allowed_agents list disables all agents even when enabled is true", () => {
     const config: SubagentRecursionConfig = { enabled: true, allowed_agents: [] }
     expect(isSubagentRecursionAllowed("explore", config)).toBe(false)

--- a/src/shared/agent-tool-restrictions.test.ts
+++ b/src/shared/agent-tool-restrictions.test.ts
@@ -1,0 +1,155 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import {
+  getAgentToolRestrictions,
+  getAgentToolRestrictionsForSpawn,
+  hasAgentToolRestrictions,
+  isSubagentRecursionAllowed,
+} from "./agent-tool-restrictions"
+import type { SubagentRecursionConfig } from "../config/schema/experimental"
+
+describe("getAgentToolRestrictions (baseline, unchanged)", () => {
+  it("returns the exploration denylist for explore", () => {
+    expect(getAgentToolRestrictions("explore")).toEqual({
+      write: false,
+      edit: false,
+      task: false,
+      call_omo_agent: false,
+    })
+  })
+
+  it("returns the exploration denylist for librarian", () => {
+    expect(getAgentToolRestrictions("librarian")).toEqual({
+      write: false,
+      edit: false,
+      task: false,
+      call_omo_agent: false,
+    })
+  })
+
+  it("returns the leaf denylist for oracle", () => {
+    expect(getAgentToolRestrictions("oracle")).toEqual({
+      write: false,
+      edit: false,
+      task: false,
+      call_omo_agent: false,
+    })
+  })
+
+  it("returns empty restrictions for unknown agents", () => {
+    expect(getAgentToolRestrictions("custom-agent")).toEqual({})
+    expect(hasAgentToolRestrictions("custom-agent")).toBe(false)
+  })
+})
+
+describe("isSubagentRecursionAllowed", () => {
+  it("returns false when recursionConfig is undefined (feature off by default)", () => {
+    expect(isSubagentRecursionAllowed("explore", undefined)).toBe(false)
+  })
+
+  it("returns false when enabled is false", () => {
+    expect(isSubagentRecursionAllowed("explore", { enabled: false })).toBe(false)
+  })
+
+  it("returns false when enabled is undefined", () => {
+    expect(isSubagentRecursionAllowed("explore", {})).toBe(false)
+  })
+
+  it("returns true for explore when enabled with default allowed_agents", () => {
+    expect(isSubagentRecursionAllowed("explore", { enabled: true })).toBe(true)
+  })
+
+  it("returns true for librarian when enabled with default allowed_agents", () => {
+    expect(isSubagentRecursionAllowed("librarian", { enabled: true })).toBe(true)
+  })
+
+  it("returns false for oracle when enabled with default allowed_agents (oracle is leaf)", () => {
+    expect(isSubagentRecursionAllowed("oracle", { enabled: true })).toBe(false)
+  })
+
+  it("returns false for unknown agents when enabled with default allowed_agents", () => {
+    expect(isSubagentRecursionAllowed("custom-agent", { enabled: true })).toBe(false)
+  })
+
+  it("respects explicit allowed_agents override", () => {
+    const config: SubagentRecursionConfig = { enabled: true, allowed_agents: ["oracle"] }
+    expect(isSubagentRecursionAllowed("oracle", config)).toBe(true)
+    expect(isSubagentRecursionAllowed("explore", config)).toBe(false)
+  })
+
+  it("is case-insensitive", () => {
+    const config: SubagentRecursionConfig = { enabled: true, allowed_agents: ["EXPLORE"] }
+    expect(isSubagentRecursionAllowed("explore", config)).toBe(true)
+    expect(isSubagentRecursionAllowed("Explore", config)).toBe(true)
+    expect(isSubagentRecursionAllowed("EXPLORE", config)).toBe(true)
+  })
+
+  it("strips invisible agent characters before matching", () => {
+    const config: SubagentRecursionConfig = { enabled: true }
+    expect(isSubagentRecursionAllowed("\u200Bexplore", config)).toBe(true)
+  })
+
+  it("empty allowed_agents list disables all agents even when enabled is true", () => {
+    const config: SubagentRecursionConfig = { enabled: true, allowed_agents: [] }
+    expect(isSubagentRecursionAllowed("explore", config)).toBe(false)
+    expect(isSubagentRecursionAllowed("librarian", config)).toBe(false)
+  })
+})
+
+describe("getAgentToolRestrictionsForSpawn", () => {
+  it("matches getAgentToolRestrictions when recursion is disabled", () => {
+    expect(getAgentToolRestrictionsForSpawn("explore", undefined)).toEqual(
+      getAgentToolRestrictions("explore"),
+    )
+    expect(getAgentToolRestrictionsForSpawn("librarian", { enabled: false })).toEqual(
+      getAgentToolRestrictions("librarian"),
+    )
+  })
+
+  it("strips call_omo_agent from explore restrictions when recursion is enabled", () => {
+    const result = getAgentToolRestrictionsForSpawn("explore", { enabled: true })
+    expect(result).toEqual({
+      write: false,
+      edit: false,
+      task: false,
+    })
+    expect(result.call_omo_agent).toBeUndefined()
+  })
+
+  it("strips call_omo_agent from librarian restrictions when recursion is enabled", () => {
+    const result = getAgentToolRestrictionsForSpawn("librarian", { enabled: true })
+    expect(result.call_omo_agent).toBeUndefined()
+    expect(result.task).toBe(false)
+  })
+
+  it("keeps task: false even when recursion is enabled (task bypasses the budget)", () => {
+    const result = getAgentToolRestrictionsForSpawn("explore", { enabled: true })
+    expect(result.task).toBe(false)
+  })
+
+  it("does NOT strip call_omo_agent for oracle even when enabled (oracle is leaf)", () => {
+    const result = getAgentToolRestrictionsForSpawn("oracle", { enabled: true })
+    expect(result.call_omo_agent).toBe(false)
+  })
+
+  it("does NOT strip anything for unknown agents (they had no restrictions to strip)", () => {
+    expect(getAgentToolRestrictionsForSpawn("custom-agent", { enabled: true })).toEqual({})
+  })
+
+  it("honors explicit allowed_agents override: oracle gets recursion", () => {
+    const result = getAgentToolRestrictionsForSpawn("oracle", {
+      enabled: true,
+      allowed_agents: ["oracle"],
+    })
+    expect(result.call_omo_agent).toBeUndefined()
+  })
+
+  it("honors explicit allowed_agents override: explore does NOT get recursion if not listed", () => {
+    const result = getAgentToolRestrictionsForSpawn("explore", {
+      enabled: true,
+      allowed_agents: ["oracle"],
+    })
+    expect(result.call_omo_agent).toBe(false)
+  })
+})

--- a/src/shared/agent-tool-restrictions.ts
+++ b/src/shared/agent-tool-restrictions.ts
@@ -1,4 +1,5 @@
 import { stripInvisibleAgentCharacters } from "./agent-display-names"
+import type { SubagentRecursionConfig } from "../config/schema/experimental"
 
 /**
  * Agent tool restrictions for session.prompt calls.
@@ -12,6 +13,8 @@ const EXPLORATION_AGENT_DENYLIST: Record<string, boolean> = {
   task: false,
   call_omo_agent: false,
 }
+
+const DEFAULT_RECURSION_ALLOWED_AGENTS = new Set(["explore", "librarian"])
 
 const AGENT_RESTRICTIONS: Record<string, Record<string, boolean>> = {
   explore: EXPLORATION_AGENT_DENYLIST,
@@ -58,4 +61,30 @@ export function getAgentToolRestrictions(agentName: string): Record<string, bool
 export function hasAgentToolRestrictions(agentName: string): boolean {
   const restrictions = getAgentToolRestrictions(agentName)
   return Object.keys(restrictions).length > 0
+}
+
+export function isSubagentRecursionAllowed(
+  agentName: string,
+  recursionConfig: SubagentRecursionConfig | undefined,
+): boolean {
+  if (!recursionConfig?.enabled) return false
+
+  const allowedAgents = recursionConfig.allowed_agents ?? Array.from(DEFAULT_RECURSION_ALLOWED_AGENTS)
+  const stripped = stripInvisibleAgentCharacters(agentName).toLowerCase()
+  return allowedAgents.some((allowed) => allowed.toLowerCase() === stripped)
+}
+
+export function getAgentToolRestrictionsForSpawn(
+  agentName: string,
+  recursionConfig: SubagentRecursionConfig | undefined,
+): Record<string, boolean> {
+  const baseRestrictions = getAgentToolRestrictions(agentName)
+  if (!isSubagentRecursionAllowed(agentName, recursionConfig)) {
+    return baseRestrictions
+  }
+  // Strip call_omo_agent from the denylist so the spawn-site default
+  // (call_omo_agent: true in manager.ts lines 578 and 887) wins. task
+  // stays blocked because it bypasses the OmO budget system.
+  const { call_omo_agent: _dropped, ...rest } = baseRestrictions
+  return rest
 }

--- a/src/shared/agent-tool-restrictions.ts
+++ b/src/shared/agent-tool-restrictions.ts
@@ -63,6 +63,10 @@ export function hasAgentToolRestrictions(agentName: string): boolean {
   return Object.keys(restrictions).length > 0
 }
 
+function normalizeAgentName(name: string): string {
+  return stripInvisibleAgentCharacters(name).trim().toLowerCase()
+}
+
 export function isSubagentRecursionAllowed(
   agentName: string,
   recursionConfig: SubagentRecursionConfig | undefined,
@@ -70,8 +74,8 @@ export function isSubagentRecursionAllowed(
   if (!recursionConfig?.enabled) return false
 
   const allowedAgents = recursionConfig.allowed_agents ?? Array.from(DEFAULT_RECURSION_ALLOWED_AGENTS)
-  const stripped = stripInvisibleAgentCharacters(agentName).toLowerCase()
-  return allowedAgents.some((allowed) => allowed.toLowerCase() === stripped)
+  const normalized = normalizeAgentName(agentName)
+  return allowedAgents.some((allowed) => normalizeAgentName(allowed) === normalized)
 }
 
 export function getAgentToolRestrictionsForSpawn(
@@ -82,9 +86,9 @@ export function getAgentToolRestrictionsForSpawn(
   if (!isSubagentRecursionAllowed(agentName, recursionConfig)) {
     return baseRestrictions
   }
-  // Strip call_omo_agent from the denylist so the spawn-site default
-  // (call_omo_agent: true in manager.ts lines 578 and 887) wins. task
-  // stays blocked because it bypasses the OmO budget system.
+  // Omit call_omo_agent so the caller's default (set to true at spawn
+  // sites before spreading restrictions) wins. task stays blocked
+  // because it bypasses the OmO budget system.
   const { call_omo_agent: _dropped, ...rest } = baseRestrictions
   return rest
 }

--- a/src/tools/call-omo-agent/sync-executor.ts
+++ b/src/tools/call-omo-agent/sync-executor.ts
@@ -2,11 +2,12 @@ import type { CallOmoAgentArgs } from "./types"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
 import { clearSessionFallbackChain, setSessionFallbackChain } from "../../hooks/model-fallback/hook"
-import { getAgentToolRestrictions, log } from "../../shared"
+import { getAgentToolRestrictionsForSpawn, log } from "../../shared"
 import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import type { FallbackEntry } from "../../shared/model-requirements"
 import { stripAgentListSortPrefix } from "../../shared/agent-display-names"
+import type { SubagentRecursionConfig } from "../../config/schema/experimental"
 import { waitForCompletion } from "./completion-poller"
 import { processMessages } from "./message-processor"
 import { createOrGetSession } from "./session-creator"
@@ -68,6 +69,7 @@ export async function executeSync(
   fallbackChain?: FallbackEntry[],
   spawnReservation?: SpawnReservation,
   model?: DelegatedModelConfig,
+  subagentRecursionConfig?: SubagentRecursionConfig,
 ): Promise<string> {
   let sessionID: string | undefined
   let createdSessionForExecution = false
@@ -108,7 +110,7 @@ export async function executeSync(
         body: {
           agent: normalizedSubagentType,
           tools: {
-            ...getAgentToolRestrictions(normalizedSubagentType),
+            ...getAgentToolRestrictionsForSpawn(normalizedSubagentType, subagentRecursionConfig),
             task: false,
             question: false,
           },

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -3,6 +3,7 @@ import { ALLOWED_AGENTS, CALL_OMO_AGENT_DESCRIPTION } from "./constants"
 import type { AllowedAgentType, CallOmoAgentArgs, ToolContextWithMetadata } from "./types"
 import type { BackgroundManager } from "../../features/background-agent"
 import type { CategoriesConfig, AgentOverrides } from "../../config/schema"
+import type { SubagentRecursionConfig } from "../../config/schema/experimental"
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import type { FallbackEntry } from "../../shared/model-requirements"
 import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
@@ -82,6 +83,7 @@ export function createCallOmoAgent(
   disabledAgents: string[] = [],
   agentOverrides?: AgentOverrides,
   userCategories?: CategoriesConfig,
+  subagentRecursionConfig?: SubagentRecursionConfig,
 ): ToolDefinition {
   const agentDescriptions = ALLOWED_AGENTS.map(
     (name) => `- ${name}: Specialized agent for ${name} tasks`,
@@ -158,14 +160,14 @@ export function createCallOmoAgent(
         let spawnReservation: Awaited<ReturnType<BackgroundManager["reserveSubagentSpawn"]>> | undefined
         try {
           spawnReservation = await backgroundManager.reserveSubagentSpawn(toolCtx.sessionID)
-          return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, spawnReservation, resolvedModel)
+          return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, spawnReservation, resolvedModel, subagentRecursionConfig)
         } catch (error) {
           spawnReservation?.rollback()
           return `Error: ${error instanceof Error ? error.message : String(error)}`
         }
       }
 
-      return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, undefined, resolvedModel)
+      return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, undefined, resolvedModel, subagentRecursionConfig)
     },
   });
 }

--- a/src/tools/delegate-task/executor-types.ts
+++ b/src/tools/delegate-task/executor-types.ts
@@ -1,5 +1,6 @@
 import type { BackgroundManager } from "../../features/background-agent"
 import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrides, SisyphusAgentConfig } from "../../config/schema"
+import type { SubagentRecursionConfig } from "../../config/schema/experimental"
 import type { OpencodeClient } from "./types"
 
 export interface ExecutorContext {
@@ -14,6 +15,7 @@ export interface ExecutorContext {
   sisyphusAgentConfig?: SisyphusAgentConfig
   onSyncSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
   syncPollTimeoutMs?: number
+  subagentRecursionConfig?: SubagentRecursionConfig
 }
 
 export interface ParentContext {

--- a/src/tools/delegate-task/sync-continuation.ts
+++ b/src/tools/delegate-task/sync-continuation.ts
@@ -3,7 +3,7 @@ import type { ExecutorContext, SessionMessage } from "./executor-types"
 import { isPlanFamily } from "./constants"
 import { publishToolMetadata } from "../../features/tool-metadata-store"
 import { getTaskToastManager } from "../../features/task-toast-manager"
-import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { getAgentToolRestrictionsForSpawn } from "../../shared/agent-tool-restrictions"
 import { getMessageDir } from "../../shared"
 import { promptWithModelSuggestionRetry } from "../../shared/model-suggestion-retry"
 import { findNearestMessageWithFields } from "../../features/hook-message-injector"
@@ -19,7 +19,7 @@ export async function executeSyncContinuation(
   executorCtx: ExecutorContext,
   deps: SyncContinuationDeps = syncContinuationDeps
 ): Promise<string> {
-  const { client, syncPollTimeoutMs, sisyphusAgentConfig } = executorCtx
+  const { client, syncPollTimeoutMs, sisyphusAgentConfig, subagentRecursionConfig } = executorCtx
   const toastManager = getTaskToastManager()
   const taskId = `resume_sync_${args.session_id!.slice(0, 8)}`
   const startTime = new Date()
@@ -86,7 +86,7 @@ export async function executeSyncContinuation(
       task: allowTask,
       call_omo_agent: true,
       question: false,
-      ...(resumeAgent ? getAgentToolRestrictions(resumeAgent) : {}),
+      ...(resumeAgent ? getAgentToolRestrictionsForSpawn(resumeAgent, subagentRecursionConfig) : {}),
     }
     setSessionTools(args.session_id!, tools)
 

--- a/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/src/tools/delegate-task/sync-prompt-sender.ts
@@ -1,5 +1,6 @@
 import type { DelegateTaskArgs, OpencodeClient, DelegatedModelConfig } from "./types"
 import type { SisyphusAgentConfig } from "../../config/schema"
+import type { SubagentRecursionConfig } from "../../config/schema/experimental"
 import { isPlanFamily } from "./constants"
 import { buildTaskPrompt } from "./prompt-builder"
 import {
@@ -7,7 +8,7 @@ import {
   promptWithModelSuggestionRetry,
 } from "../../shared/model-suggestion-retry"
 import { formatDetailedError } from "./error-formatting"
-import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { getAgentToolRestrictionsForSpawn } from "../../shared/agent-tool-restrictions"
 import { stripInvisibleAgentCharacters } from "../../shared/agent-display-names"
 import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { setSessionTools } from "../../shared/session-tools-store"
@@ -62,6 +63,7 @@ export async function sendSyncPrompt(
     toastManager: { removeTask: (id: string) => void } | null | undefined
     taskId: string | undefined
     sisyphusAgentConfig?: SisyphusAgentConfig
+    subagentRecursionConfig?: SubagentRecursionConfig
   },
   deps: SendSyncPromptDeps = sendSyncPromptDeps
 ): Promise<string | null> {
@@ -72,7 +74,7 @@ export async function sendSyncPrompt(
     task: allowTask,
     call_omo_agent: true,
     question: false,
-    ...getAgentToolRestrictions(input.agentToUse),
+    ...getAgentToolRestrictionsForSpawn(input.agentToUse, input.subagentRecursionConfig),
   }
   setSessionTools(input.sessionID, tools)
 

--- a/src/tools/delegate-task/sync-task.ts
+++ b/src/tools/delegate-task/sync-task.ts
@@ -146,6 +146,7 @@ export async function executeSyncTask(
       toastManager,
       taskId,
       sisyphusAgentConfig: executorCtx.sisyphusAgentConfig,
+      subagentRecursionConfig: executorCtx.subagentRecursionConfig,
     })
     if (promptError) {
       const promptResult = await retrySyncPromptWithFallbacks({
@@ -163,6 +164,7 @@ export async function executeSyncTask(
             toastManager,
             taskId,
             sisyphusAgentConfig: executorCtx.sisyphusAgentConfig,
+            subagentRecursionConfig: executorCtx.subagentRecursionConfig,
           })
         },
       })

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
 import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrides, SisyphusAgentConfig } from "../../config/schema"
+import type { SubagentRecursionConfig } from "../../config/schema/experimental"
 import type {
   AvailableCategory,
   AvailableSkill,
@@ -70,6 +71,7 @@ export interface DelegateTaskToolOptions {
   sisyphusAgentConfig?: SisyphusAgentConfig
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
   syncPollTimeoutMs?: number
+  subagentRecursionConfig?: SubagentRecursionConfig
 }
 
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"


### PR DESCRIPTION
## Summary

Adds a configuration flag that lets research subagents (explore, librarian) spawn further subagents via `call_omo_agent`. **Default OFF** — when absent or `{ enabled: false }`, behavior is identical to before. Existing `background_task.maxDepth` (default 3) and `maxDescendants` (default 50) guardrails stay active.

Resolves item 5 of the 6-item subagent tooling upgrade plan from NEXT_SESSION_HANDOFF.md §F.

## Config shape

\`\`\`jsonc
// oh-my-openagent.json
{
  \"experimental\": {
    \"subagent_recursion\": {
      \"enabled\": true,
      \"allowed_agents\": [\"explore\", \"librarian\"]  // default if omitted
    }
  }
}
\`\`\`

## Design choices

**Only \`call_omo_agent\` is ungated.** The core OpenCode \`task\` tool stays blocked for subagents even when the flag is on, because \`task\` bypasses the OmO \`BackgroundManager.assertCanSpawn\` budget system. \`call_omo_agent\` goes through the budget, so depth and descendant limits are enforced exactly as they already are for orchestrator spawns.

**Oracle is NOT in the default \`allowed_agents\` list.** Oracle is a leaf consultant by design; enabling recursion for it would invite runaway consultation chains. Users who want to opt Oracle in can still do so explicitly via \`allowed_agents: [\"oracle\"]\`.

**Existing \`getAgentToolRestrictions\` signature unchanged.** 15 call sites. A new \`getAgentToolRestrictionsForSpawn\` wraps it with the flag-aware strip. Only the 2 \`manager.ts\` spawn sites migrate to the new function. This keeps the blast radius minimal.

## Files changed

| File | Change |
|---|---|
| \`src/config/schema/experimental.ts\` | Adds \`SubagentRecursionConfigSchema\` and \`experimental.subagent_recursion\` field |
| \`src/shared/agent-tool-restrictions.ts\` | Adds \`isSubagentRecursionAllowed\` and \`getAgentToolRestrictionsForSpawn\`. Exports automatically via shared barrel |
| \`src/features/background-agent/manager.ts\` | New \`subagentRecursionConfig\` constructor option; both spawn sites (line 585 initial, line 894 resume) call the new function |
| \`src/create-managers.ts\` | Threads \`pluginConfig.experimental?.subagent_recursion\` into \`BackgroundManager\` |
| \`src/shared/agent-tool-restrictions.test.ts\` | NEW - 23 test cases |

## Test coverage

23 new test cases in the added test file cover:

- Baseline behavior (\`getAgentToolRestrictions\` unchanged for explore, librarian, oracle, unknown)
- Flag-off: \`isSubagentRecursionAllowed\` returns false for undefined, \`{}\`, \`{ enabled: false }\`
- Flag-on defaults: explore/librarian allowed, oracle still leaf, unknowns still blocked
- Case-insensitive agent name matching
- Invisible-agent-character stripping (ZWSP edge case)
- Explicit \`allowed_agents\` override (oracle can opt in; explore can opt out)
- Empty \`allowed_agents\` array disables everything
- \`getAgentToolRestrictionsForSpawn\` strips only \`call_omo_agent\`, keeps \`task: false\`

## Verification

- \`bun run typecheck\` — clean
- \`bun test\` — **5655 pass / 0 fail** (5640 → 5655)
- \`lsp_diagnostics\` on \`src/\` — no new errors

## Risk

**Low.** Default-off means zero behavior change for users who don't opt in. The \`task: false\` invariant is preserved so no path to bypass the budget system. Guardrails (\`maxDepth\`, \`maxDescendants\`) already exist and are tested — we're just letting them actually fire.

## Follow-up (NOT in this PR)

Items 1-4 and 6 of the 6-item plan live in \`~/.config/opencode\` (config repo), not the fork:
- Item 1: WarpGrep routing rule in \`oh-my-openagent.json\` explore/librarian prompts
- Item 2: Install DeepWiki MCP + GitHub MCP
- Item 3: Update \`deepwiki-cli/SKILL.md\` routing
- Item 4: Install \`github-code-search\` CLI + update \`gh-cli.md\` skill
- Item 6: New \`tooling/remote-repo-exploration.md\` skill

That repo currently has 18 modified files + 22 untracked items of unrelated WIP, which is why those items were skipped this session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in subagent recursion via `experimental.subagent_recursion`. When enabled, `explore` and `librarian` can spawn subagents with `call_omo_agent` across async and sync paths; defaults off, guardrails (`background_task.maxDepth`, `maxDescendants`) still apply, and `task` stays blocked.

- **New Features**
  - New config: `experimental.subagent_recursion` with `enabled` and `allowed_agents` (defaults to `["explore","librarian"]`; `oracle` excluded). Enable via `oh-my-openagent.json`.
  - Only ungates `call_omo_agent`; `task: false` for subagents to enforce budgets.
  - Adds `getAgentToolRestrictionsForSpawn` and `isSubagentRecursionAllowed`; threaded through `BackgroundManager`, `tool-registry`, `call_omo_agent` sync, and `delegate-task` sync/resume.

- **Bug Fixes**
  - Recursion flag now applies to sync spawns (`call_omo_agent` synchronous, `delegate-task` sync/resume); previously only async/resume paths honored it.
  - Normalizes agent names and `allowed_agents` entries (case-insensitive; strips invisibles/whitespace).

<sup>Written for commit 9c4405bcfa19f3eaab468476724b13327538bc6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

