### PR TITLE
chore(schema): fork $id + regen schema + CI drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,19 @@ jobs:
           test -f dist/index.js || (echo "ERROR: dist/index.js not found!" && exit 1)
           test -f dist/index.d.ts || (echo "ERROR: dist/index.d.ts not found!" && exit 1)
 
+      - name: Fail PR on schema drift
+        if: github.event_name == 'pull_request'
+        run: |
+          if git diff --quiet assets/oh-my-opencode.schema.json; then
+            echo "Schema is up to date"
+          else
+            echo "::error::assets/oh-my-opencode.schema.json is out of sync with src/config/schema/. Run 'bun run build:schema' locally and commit the result."
+            git diff assets/oh-my-opencode.schema.json
+            exit 1
+          fi
+
       - name: Auto-commit schema changes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev')
         run: |
           if git diff --quiet assets/oh-my-opencode.schema.json; then
             echo "No schema changes to commit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,26 +99,48 @@ jobs:
       - name: Fail PR on schema drift
         if: github.event_name == 'pull_request'
         run: |
-          if git diff --quiet assets/oh-my-opencode.schema.json; then
+          if [ ! -f assets/oh-my-opencode.schema.json ]; then
+            echo "::error::assets/oh-my-opencode.schema.json was deleted. The file is required; run 'bun run build:schema' locally and commit the result."
+            exit 1
+          fi
+          STATUS=$(git status --porcelain assets/oh-my-opencode.schema.json)
+          if [ -z "$STATUS" ]; then
             echo "Schema is up to date"
           else
             echo "::error::assets/oh-my-opencode.schema.json is out of sync with src/config/schema/. Run 'bun run build:schema' locally and commit the result."
+            echo "::group::git status"
+            echo "$STATUS"
+            echo "::endgroup::"
+            echo "::group::git diff"
             git diff assets/oh-my-opencode.schema.json
+            echo "::endgroup::"
             exit 1
           fi
 
       - name: Auto-commit schema changes
         if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev')
+        id: schema-commit
         run: |
-          if git diff --quiet assets/oh-my-opencode.schema.json; then
+          if [ ! -f assets/oh-my-opencode.schema.json ]; then
+            echo "::error::assets/oh-my-opencode.schema.json is missing. Run 'bun run build:schema' and commit the result."
+            exit 1
+          fi
+          STATUS=$(git status --porcelain assets/oh-my-opencode.schema.json)
+          if [ -z "$STATUS" ]; then
             echo "No schema changes to commit"
+            echo "committed_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           else
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add assets/oh-my-opencode.schema.json
             git commit -m "chore: auto-update schema.json"
             git push
+            NEW_SHA=$(git rev-parse HEAD)
+            echo "committed_sha=${NEW_SHA}" >> "$GITHUB_OUTPUT"
           fi
+
+    outputs:
+      committed_sha: ${{ steps.schema-commit.outputs.committed_sha }}
 
   draft-release:
     runs-on: ubuntu-latest
@@ -130,6 +152,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ needs.build.outputs.committed_sha || github.sha }}
 
       - run: git fetch --force --tags
 
@@ -151,7 +174,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NOTES: ${{ steps.notes.outputs.notes }}
-          TARGET_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ needs.build.outputs.committed_sha || github.sha }}
         run: |
           EXISTING_DRAFT=$(gh release list --json tagName,isDraft --jq '.[] | select(.isDraft == true and .tagName == "next") | .tagName')
           

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+  "$id": "https://raw.githubusercontent.com/Vacbo/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "title": "Oh My OpenCode Configuration",
   "description": "Configuration schema for oh-my-opencode plugin",
   "type": "object",
@@ -24,8 +24,7 @@
     "disabled_mcps": {
       "type": "array",
       "items": {
-        "type": "string",
-        "minLength": 1
+        "type": "string"
       }
     },
     "disabled_agents": {
@@ -37,16 +36,7 @@
     "disabled_skills": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": [
-          "playwright",
-          "agent-browser",
-          "dev-browser",
-          "frontend-ui-ux",
-          "git-master",
-          "review-work",
-          "ai-slop-remover"
-        ]
+        "type": "string"
       }
     },
     "disabled_hooks": {
@@ -58,17 +48,7 @@
     "disabled_commands": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": [
-          "init-deep",
-          "ralph-loop",
-          "ulw-loop",
-          "cancel-ralph",
-          "refactor",
-          "start-work",
-          "stop-continuation",
-          "remove-ai-slops"
-        ]
+        "type": "string"
       }
     },
     "disabled_tools": {
@@ -5469,6 +5449,21 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 9007199254740991
+        },
+        "subagent_recursion": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowed_agents": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -5526,6 +5521,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "hide_nested_by_default": {
+              "type": "boolean"
             }
           },
           "additionalProperties": {

--- a/script/build-schema-document.ts
+++ b/script/build-schema-document.ts
@@ -9,7 +9,7 @@ export function createOhMyOpenCodeJsonSchema(): Record<string, unknown> {
 
   return {
     $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+    $id: "https://raw.githubusercontent.com/Vacbo/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
     title: "Oh My OpenCode Configuration",
     description: "Configuration schema for oh-my-opencode plugin",
     ...jsonSchema,


### PR DESCRIPTION
## Summary

Three fixes in one PR to resolve long-running schema drift:

1. Fork the \`\$id\` in \`script/build-schema-document.ts\` from \`code-yeongyu/oh-my-openagent/dev\` to \`Vacbo/oh-my-opencode/master\`.
2. Regenerate \`assets/oh-my-opencode.schema.json\` so it matches current Zod sources. Picks up two fields that were missing: \`experimental.subagent_recursion\` (from #65, shipped in v3.19.0) and \`skills.hide_nested_by_default\` (from #54).
3. Add a CI check that fails PRs on schema drift, and expand auto-commit to \`dev\` as well as \`master\`.

## How this happened

PR #54 and PR #65 changed the Zod config schemas but didn't regenerate \`assets/oh-my-opencode.schema.json\`. The auto-commit in \`ci.yml\` was gated to \`master\`-only, so drift on \`dev\` never triggered regeneration. After each publish-to-\`master\` force-push, \`master\` CI finally ran \`bun run build\` (which calls \`build:schema\`) and auto-committed — but the fix applied forwards to \`master\` only, not retroactively to \`dev\`.

User running a local schema-validated config reports that the JSON schema pinned at \`raw.githubusercontent.com/Vacbo/oh-my-opencode/master\` was missing \`subagent_recursion\` even though v3.19.0 shipped with the feature — that's this drift surfacing.

## Changes

| File | Change |
|---|---|
| \`script/build-schema-document.ts\` | \`\$id\` → \`Vacbo/oh-my-opencode/master\` |
| \`assets/oh-my-opencode.schema.json\` | Regenerated (adds \`subagent_recursion\`, \`hide_nested_by_default\`, new \`\$id\`, canonical enum/minLength output from current Zod) |
| \`.github/workflows/ci.yml\` | New 'Fail PR on schema drift' step + auto-commit extended to \`dev\` |

## Verification

- \`bun run build:schema\` — deterministic regen, same output
- \`bun run typecheck\` — clean
- \`bun test\` — **5636 pass / 0 fail**
- The new PR-level 'Fail on schema drift' check will self-test on this PR's CI run

## What this prevents

Going forward:
- Any PR that changes \`src/config/schema/*.ts\` without also running \`build:schema\` will fail the 'Fail PR on schema drift' check → reviewer sees the failure, contributor regenerates, no silent drift.
- Any push to \`dev\` that contains drift will auto-commit the regenerated schema (same behavior that currently only works on \`master\`).

## Risk

Minimal. The schema JSON is a published artifact consumed by editors doing schema validation — the new schema is strictly more accurate than the old one (more fields, correct \`\$id\`). No runtime behavior change on the plugin itself.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long-running schema drift by updating the schema $id, regenerating `assets/oh-my-opencode.schema.json`, and tightening CI drift checks. Restores missing fields, keeps `dev` and `master` in sync, and ensures `draft-release` targets the post auto-commit SHA.

- **Bug Fixes**
  - Set `$id` to `https://raw.githubusercontent.com/Vacbo/oh-my-opencode/master/assets/oh-my-opencode.schema.json`.
  - Regenerated schema adds `experimental.subagent_recursion` and `skills.hide_nested_by_default`; drops stale enum/minLength artifacts.
  - CI: PRs fail on schema drift or missing schema; pushes to `dev`/`master` auto-commit schema changes; `draft-release` uses the auto-committed SHA.

<sup>Written for commit 7d4009a1100c903f416bdaef89c340162f1cb752. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

