### PR TITLE
fix(agents): teach recursion-enabled subagents how to delegate

### DIFF
--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { BuiltinAgentName, AgentOverrides, AgentFactory, AgentPromptMetadata } from "./types"
 import type { CategoriesConfig, GitMasterConfig } from "../config/schema"
+import type { SubagentRecursionConfig } from "../config/schema/experimental"
 import type { LoadedSkill } from "../features/opencode-skill-loader/types"
 import type { BrowserAutomationProvider } from "../config/schema"
 import { createSisyphusAgent } from "./sisyphus"
@@ -71,7 +72,8 @@ export async function createBuiltinAgents(
   uiSelectedModel?: string,
   disabledSkills?: Set<string>,
   useTaskSystem = false,
-  disableOmoEnv = false
+  disableOmoEnv = false,
+  subagentRecursionConfig?: SubagentRecursionConfig,
 ): Promise<Record<string, AgentConfig>> {
 
   const connectedProviders = readConnectedProvidersCache()
@@ -117,6 +119,7 @@ export async function createBuiltinAgents(
     isFirstRunNoCache,
     disabledSkills,
     disableOmoEnv,
+    subagentRecursionConfig,
   })
 
   const sisyphusConfig = maybeCreateSisyphusConfig({

--- a/src/agents/builtin-agents/general-agents.ts
+++ b/src/agents/builtin-agents/general-agents.ts
@@ -98,13 +98,6 @@ export function collectPendingBuiltinAgents(input: {
 
     let config = buildAgent(source, model, mergedCategories, gitMasterConfig, browserProvider, disabledSkills)
 
-    if (config.prompt) {
-      config = {
-        ...config,
-        prompt: appendSubagentRecursionPrompt(config.prompt, agentName, subagentRecursionConfig),
-      }
-    }
-
     // Apply resolved variant from model fallback chain
     if (resolvedVariant) {
       config = { ...config, variant: resolvedVariant }
@@ -115,6 +108,13 @@ export function collectPendingBuiltinAgents(input: {
     }
 
     config = applyOverrides(config, override, mergedCategories, directory)
+
+    if (config.prompt) {
+      config = {
+        ...config,
+        prompt: appendSubagentRecursionPrompt(config.prompt, agentName, subagentRecursionConfig),
+      }
+    }
 
     // Store for later - will be added after sisyphus and hephaestus
     pendingAgentConfigs.set(name, config)

--- a/src/agents/builtin-agents/general-agents.ts
+++ b/src/agents/builtin-agents/general-agents.ts
@@ -2,7 +2,9 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { BuiltinAgentName, AgentOverrides, AgentPromptMetadata } from "../types"
 import type { CategoryConfig, GitMasterConfig } from "../../config/schema"
 import type { BrowserAutomationProvider } from "../../config/schema"
+import type { SubagentRecursionConfig } from "../../config/schema/experimental"
 import type { AvailableAgent } from "../dynamic-agent-prompt-builder"
+import { appendSubagentRecursionPrompt } from "../subagent-recursion-prompt"
 import { AGENT_MODEL_REQUIREMENTS, isModelAvailable } from "../../shared"
 import { buildAgent, isFactory } from "../agent-builder"
 import { applyOverrides } from "./agent-overrides"
@@ -26,6 +28,7 @@ export function collectPendingBuiltinAgents(input: {
   disabledSkills?: Set<string>
   useTaskSystem?: boolean
   disableOmoEnv?: boolean
+  subagentRecursionConfig?: SubagentRecursionConfig
 }): { pendingAgentConfigs: Map<string, AgentConfig>; availableAgents: AvailableAgent[] } {
   const {
     agentSources,
@@ -42,6 +45,7 @@ export function collectPendingBuiltinAgents(input: {
     isFirstRunNoCache,
     disabledSkills,
     disableOmoEnv = false,
+    subagentRecursionConfig,
   } = input
 
   const availableAgents: AvailableAgent[] = []
@@ -93,6 +97,13 @@ export function collectPendingBuiltinAgents(input: {
     const { model, variant: resolvedVariant } = resolution
 
     let config = buildAgent(source, model, mergedCategories, gitMasterConfig, browserProvider, disabledSkills)
+
+    if (config.prompt) {
+      config = {
+        ...config,
+        prompt: appendSubagentRecursionPrompt(config.prompt, agentName, subagentRecursionConfig),
+      }
+    }
 
     // Apply resolved variant from model fallback chain
     if (resolvedVariant) {

--- a/src/agents/explore.ts
+++ b/src/agents/explore.ts
@@ -33,14 +33,7 @@ export function createExploreAgent(model: string): AgentConfig {
     "call_omo_agent",
   ])
 
-  return {
-    description:
-      'Contextual grep for codebases. Answers "Where is X?", "Which file has Y?", "Find the code that does Z". Fire multiple in parallel for broad searches. Specify thoroughness: "quick" for basic, "medium" for moderate, "very thorough" for comprehensive analysis. (Explore - OhMyOpenCode)',
-    mode: MODE,
-    model,
-    temperature: 0.1,
-    ...restrictions,
-    prompt: `You are a codebase search specialist. Your job: find files and code, return actionable results.
+  const basePrompt = `You are a codebase search specialist. Your job: find files and code, return actionable results.
 
 ## Your Mission
 
@@ -116,7 +109,16 @@ Use the right tool for the job:
 - **File patterns** (find by name/extension): glob
 - **History/evolution** (when added, who changed): git commands
 
-Flood with parallel calls. Cross-validate findings across multiple tools.`,
+Flood with parallel calls. Cross-validate findings across multiple tools.`
+
+  return {
+    description:
+      'Contextual grep for codebases. Answers "Where is X?", "Which file has Y?", "Find the code that does Z". Fire multiple in parallel for broad searches. Specify thoroughness: "quick" for basic, "medium" for moderate, "very thorough" for comprehensive analysis. (Explore - OhMyOpenCode)',
+    mode: MODE,
+    model,
+    temperature: 0.1,
+    ...restrictions,
+    prompt: basePrompt,
   }
 }
 createExploreAgent.mode = MODE

--- a/src/agents/librarian.ts
+++ b/src/agents/librarian.ts
@@ -30,14 +30,7 @@ export function createLibrarianAgent(model: string): AgentConfig {
     "call_omo_agent",
   ])
 
-  return {
-    description:
-      "Specialized codebase understanding agent for multi-repository analysis, searching remote codebases, retrieving official documentation, and finding implementation examples using GitHub CLI, Context7, and Web Search. MUST BE USED when users ask to look up code in remote repositories, explain library internals, or find usage examples in open source. (Librarian - OhMyOpenCode)",
-    mode: MODE,
-    model,
-    temperature: 0.1,
-    ...restrictions,
-    prompt: `# THE LIBRARIAN
+  const basePrompt = `# THE LIBRARIAN
 
 You are **THE LIBRARIAN**, a specialized open-source codebase understanding agent.
 
@@ -314,7 +307,16 @@ grep_app_searchGitHub(query: "useQuery")
 4. **USE MARKDOWN**: Code blocks with language identifiers
 5. **BE CONCISE**: Facts > opinions, evidence > speculation
 
-`,
+`
+
+  return {
+    description:
+      "Specialized codebase understanding agent for multi-repository analysis, searching remote codebases, retrieving official documentation, and finding implementation examples using GitHub CLI, Context7, and Web Search. MUST BE USED when users ask to look up code in remote repositories, explain library internals, or find usage examples in open source. (Librarian - OhMyOpenCode)",
+    mode: MODE,
+    model,
+    temperature: 0.1,
+    ...restrictions,
+    prompt: basePrompt,
   }
 }
 createLibrarianAgent.mode = MODE

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -250,6 +250,9 @@ export function createOracleAgent(model: string): AgentConfig {
     "task",
   ]);
 
+  const isGpt = isGptModel(model);
+  const basePrompt = isGpt ? ORACLE_GPT_PROMPT : ORACLE_DEFAULT_PROMPT;
+
   const base = {
     description:
       "Read-only consultation agent. High-IQ reasoning specialist for debugging hard problems and high-difficulty architecture design. (Oracle - OhMyOpenCode)",
@@ -257,13 +260,12 @@ export function createOracleAgent(model: string): AgentConfig {
     model,
     temperature: 0.1,
     ...restrictions,
-    prompt: ORACLE_DEFAULT_PROMPT,
+    prompt: basePrompt,
   } as AgentConfig;
 
-  if (isGptModel(model)) {
+  if (isGpt) {
     return {
       ...base,
-      prompt: ORACLE_GPT_PROMPT,
       reasoningEffort: "medium",
       textVerbosity: "high",
     } as AgentConfig;

--- a/src/agents/subagent-recursion-prompt.test.ts
+++ b/src/agents/subagent-recursion-prompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  appendSubagentRecursionPrompt,
+  getSubagentRecursionPrompt,
+} from "./subagent-recursion-prompt"
+
+describe("subagent recursion prompt helper", () => {
+  test("returns undefined when recursion is disabled", () => {
+    expect(getSubagentRecursionPrompt("explore", undefined)).toBeUndefined()
+    expect(getSubagentRecursionPrompt("explore", { enabled: false })).toBeUndefined()
+  })
+
+  test("returns prompt block for explore when enabled by default", () => {
+    const block = getSubagentRecursionPrompt("explore", { enabled: true })
+
+    expect(block).toContain("Nested Delegation Available")
+    expect(block).toContain("call_omo_agent")
+    expect(block).toContain("another delegation or research tool with the same purpose")
+    expect(block).toContain("task` remains unavailable")
+  })
+
+  test("returns undefined for oracle unless explicitly allowed", () => {
+    expect(getSubagentRecursionPrompt("oracle", { enabled: true })).toBeUndefined()
+    expect(getSubagentRecursionPrompt("oracle", { enabled: true, allowed_agents: ["oracle"] })).toBeDefined()
+  })
+
+  test("appends the block only when allowed", () => {
+    const basePrompt = "Base prompt"
+
+    expect(appendSubagentRecursionPrompt(basePrompt, "explore", { enabled: true })).toContain(
+      "Nested Delegation Available",
+    )
+    expect(appendSubagentRecursionPrompt(basePrompt, "oracle", { enabled: true })).toBe(basePrompt)
+  })
+})

--- a/src/agents/subagent-recursion-prompt.ts
+++ b/src/agents/subagent-recursion-prompt.ts
@@ -1,0 +1,66 @@
+import type { SubagentRecursionConfig } from "../config/schema/experimental"
+import { isSubagentRecursionAllowed } from "../shared/agent-tool-restrictions"
+
+/**
+ * Prompt block appended to subagent system prompts when the agent is allowed
+ * to spawn nested subagents via call_omo_agent. Only rendered when the agent
+ * is listed in experimental.subagent_recursion.allowed_agents (and the feature
+ * is enabled). Keeps wording generic so it applies across explore, librarian,
+ * and oracle without per-agent customisation.
+ */
+const RECURSION_INSTRUCTION_BLOCK = `
+## Nested Delegation Available
+
+You MAY use \`call_omo_agent\` for nested delegation when your task is broader
+than a single search or consultation can cover. If your current tool list
+contains another delegation or research tool with the same purpose, you may use
+that instead - choose based on the tools you actually have, not on this example
+alone. Subagent budgets (max depth, max descendants) are enforced by the
+runtime - do not try to work around them.
+
+When to spawn a nested subagent:
+- Your task decomposes into 2+ independent research angles that would each
+  need their own focused search.
+- You need information from a domain outside your specialty (e.g. an
+  \`explore\` subagent delegating external-library research to \`librarian\`).
+- A single query would either (a) exhaust your context window or (b)
+  produce output too noisy to be useful.
+
+When NOT to spawn a nested subagent:
+- You can answer the question directly from the tools you already have.
+- The work is small and would finish faster than the spawn overhead.
+- You would be spawning another agent of your own type just to split a
+  search that belongs in one place.
+
+Typical call pattern:
+\`\`\`
+call_omo_agent(
+  subagent_type="explore" | "librarian" | "oracle",
+  prompt="<clear, self-contained task with success criteria>",
+  run_in_background=true,
+  load_skills=[]
+)
+\`\`\`
+
+\`task\` remains unavailable to you by design. Use whichever equivalent
+delegation tool is actually available to you, with \`call_omo_agent\` as the
+default path in this environment.
+`.trim()
+
+export function getSubagentRecursionPrompt(
+  agentName: string,
+  recursionConfig: SubagentRecursionConfig | undefined,
+): string | undefined {
+  if (!isSubagentRecursionAllowed(agentName, recursionConfig)) return undefined
+  return RECURSION_INSTRUCTION_BLOCK
+}
+
+export function appendSubagentRecursionPrompt(
+  basePrompt: string,
+  agentName: string,
+  recursionConfig: SubagentRecursionConfig | undefined,
+): string {
+  const block = getSubagentRecursionPrompt(agentName, recursionConfig)
+  if (!block) return basePrompt
+  return `${basePrompt}\n\n${block}`
+}

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -1537,4 +1537,39 @@ describe("Deadlock prevention - fetchAvailableModels must not receive client", (
     connectedSpy.mockRestore()
     fetchSpy.mockRestore()
   })
+
+  test("createBuiltinAgents threads subagentRecursionConfig into subagent prompts", async () => {
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set([
+        "openai/gpt-5.4",
+        "anthropic/claude-opus-4-7",
+        "fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo",
+      ])
+    )
+
+    try {
+      const agents = await createBuiltinAgents(
+        [],
+        {},
+        undefined,
+        TEST_DEFAULT_MODEL,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        false,
+        { enabled: true, allowed_agents: ["explore", "librarian", "oracle"] },
+      )
+
+      expect(agents.explore.prompt).toContain("Nested Delegation Available")
+      expect(agents.librarian.prompt).toContain("Nested Delegation Available")
+      expect(agents.oracle.prompt).toContain("Nested Delegation Available")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
 })

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -186,6 +186,7 @@ export async function applyAgentConfig(params: {
     disabledSkills,
     useTaskSystem,
     disableOmoEnv,
+    params.pluginConfig.experimental?.subagent_recursion,
   );
 
   const disabledAgentNames = new Set(

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -1558,7 +1558,7 @@ describe("disable_omo_env pass-through", () => {
       createBuiltinAgentsMock.mock.calls[createBuiltinAgentsMock.mock.calls.length - 1]
     expect(lastCall).toBeDefined()
     const disableOmoEnv = Array.isArray(lastCall)
-      ? lastCall[lastCall.length - 1]
+      ? lastCall[12]
       : undefined
     expect(disableOmoEnv).toBe(true)
   })
@@ -1595,7 +1595,7 @@ describe("disable_omo_env pass-through", () => {
       createBuiltinAgentsMock.mock.calls[createBuiltinAgentsMock.mock.calls.length - 1]
     expect(lastCall).toBeDefined()
     const disableOmoEnv = Array.isArray(lastCall)
-      ? lastCall[lastCall.length - 1]
+      ? lastCall[12]
       : undefined
     expect(disableOmoEnv).toBe(false)
   })

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -1558,7 +1558,7 @@ describe("disable_omo_env pass-through", () => {
       createBuiltinAgentsMock.mock.calls[createBuiltinAgentsMock.mock.calls.length - 1]
     expect(lastCall).toBeDefined()
     const disableOmoEnv = Array.isArray(lastCall)
-      ? lastCall[12]
+      ? lastCall[lastCall.length - 2]
       : undefined
     expect(disableOmoEnv).toBe(true)
   })
@@ -1595,7 +1595,7 @@ describe("disable_omo_env pass-through", () => {
       createBuiltinAgentsMock.mock.calls[createBuiltinAgentsMock.mock.calls.length - 1]
     expect(lastCall).toBeDefined()
     const disableOmoEnv = Array.isArray(lastCall)
-      ? lastCall[12]
+      ? lastCall[lastCall.length - 2]
       : undefined
     expect(disableOmoEnv).toBe(false)
   })


### PR DESCRIPTION
## Summary
- add a shared recursion prompt block that explains when nested delegation is appropriate and makes `call_omo_agent` the default path without forbidding equivalent available delegation/research tools
- append that block only when `experimental.subagent_recursion` is enabled for the current agent, leaving default behavior unchanged
- cover the helper, prompt injection, and the new `createBuiltinAgents(..., subagentRecursionConfig)` argument threading with tests

## Why
Subagents could already *use* recursion once the runtime flag was enabled, but they were never *told* that nested delegation existed. In practice they would only recurse when explicitly instructed by the caller. This patch makes the feature discoverable to the agents themselves while keeping the prompt conditional on the config flag.

## Commit plan
1. `feat(agents): add subagent recursion prompt helper`
2. `refactor(agents): extract subagent base prompts`
3. `feat(agents): thread recursion config into registration`
4. `test(agents): cover recursion prompt injection`

## Verification
- `bun run typecheck`
- `bun test`

Full local result: **5641 pass / 0 fail**.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vacbo/oh-my-opencode/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teaches recursion-enabled subagents to delegate by appending a shared “Nested Delegation” prompt when `experimental.subagent_recursion` allows it. Also fixes prompt loss after overrides so the block is preserved.

- **New Features**
  - Added `getSubagentRecursionPrompt` and `appendSubagentRecursionPrompt` to add a shared block recommending `call_omo_agent` for nested delegation without forbidding equivalent tools.
  - Appends only when `experimental.subagent_recursion.enabled` is true and the agent is allowed; `oracle` is gated unless explicitly whitelisted.
  - Threaded `subagentRecursionConfig` into `createBuiltinAgents` and through the `agent-config-handler`.

- **Bug Fixes**
  - Preserve the recursion prompt after applying agent overrides in built-in agent registration; tests cover injection and config threading.

<sup>Written for commit 31ed4e6a9d389b5edfa3ef5d758fce1d4e753b5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

